### PR TITLE
fix: support both settings and empty line numbers in rule config

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -215,7 +215,7 @@ module.exports = {
     },
     create: function(context) {
         var options = context.options;
-        var numNewlines = options.length > 2 ? options[2] : 1;
+        var numNewlines = options.length > 2 && typeof options[2] === "number" ? options[2] : 1;
         var eol = getEOL(options);
 
         // If just one option then read comment from file


### PR DESCRIPTION
Original logic was expecting the third argument of the header rule to always be the number of empty lines expected. Unfortunately, after line-ending character settigns were added as an optional config argument, the logic no longer stands true.