### PR TITLE
test: enforce unix EOL in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "eslint": "^9.32.0",
         "eslint-plugin-jsdoc": "^52.0.4",
         "mocha": "^11.7.1",
-        "nyc": "^17.1.0"
+        "nyc": "^17.1.0",
+        "testdouble": "^3.20.2"
       },
       "peerDependencies": {
         "eslint": ">=7.7.0"
@@ -1698,6 +1699,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -1795,6 +1806,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -1874,6 +1898,22 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1913,6 +1953,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -2227,6 +2277,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -2860,6 +2917,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
@@ -2984,6 +3048,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/quibble": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.9.2.tgz",
+      "integrity": "sha512-BrL7hrZcbyyt5ZDfePkGFDc3m82uUtxCPOnpRUrkOdtBnmV9ldQKxXORkKL8eIzToRNaCpIPyKyfdfq/tBlFAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">= 0.14.0"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -3037,6 +3115,27 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3329,6 +3428,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/stringify-object-es5": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stringify-object-es5/-/stringify-object-es5-2.5.0.tgz",
+      "integrity": "sha512-vE7Xdx9ylG4JI16zy7/ObKUB+MtxuMcWlj/WHHr3+yAlQoN6sst2stU9E+2Qs3OrlJw/Pf3loWxL1GauEHf6MA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "is-plain-obj": "^1.0.0",
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-object-es5/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
@@ -3407,6 +3530,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -3456,6 +3592,29 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/testdouble": {
+      "version": "3.20.2",
+      "resolved": "https://registry.npmjs.org/testdouble/-/testdouble-3.20.2.tgz",
+      "integrity": "sha512-790e9vJKdfddWNOaxW1/V9FcMk48cPEl3eJSj2i8Hh1fX89qArEJ6cp3DBnaECpGXc3xKJVWbc1jeNlWYWgiMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "quibble": "^0.9.2",
+        "stringify-object-es5": "^2.5.0",
+        "theredoc": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/theredoc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/theredoc/-/theredoc-1.0.0.tgz",
+      "integrity": "sha512-KU3SA3TjRRM932jpNfD3u4Ec3bSvedyo5ITPI7zgWYnKep7BwQQaxlhI9qbO+lKJoRnoAbEVfMcAHRuKVYikDA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "eslint": "^9.32.0",
     "eslint-plugin-jsdoc": "^52.0.4",
     "mocha": "^11.7.1",
-    "nyc": "^17.1.0"
+    "nyc": "^17.1.0",
+    "testdouble": "^3.20.2"
   },
   "peerDependencies": {
     "eslint": ">=7.7.0"

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -24,286 +24,296 @@
 
 "use strict";
 
-var rule = require("../../../lib/rules/header");
-var RuleTester = require("eslint").RuleTester;
+const td = require("testdouble");
+// This needs to be called before any required module requires the `os` package.
+const os = td.replace("os");
 
-var ruleTester = new RuleTester();
-ruleTester.run("header", rule, {
-    valid: [
-        {
-            code: "/*Copyright 2015, My Company*/\nconsole.log(1);",
-            options: ["block", "Copyright 2015, My Company"]
-        },
-        {
-            code: "//Copyright 2015, My Company\nconsole.log(1);",
-            options: ["line", "Copyright 2015, My Company"]
-        },
-        {
-            code: "/*Copyright 2015, My Company*/",
-            options: ["block", "Copyright 2015, My Company", 0]
-        },
-        {
-            code: "//Copyright 2015\n//My Company\nconsole.log(1)",
-            options: ["line", "Copyright 2015\nMy Company"]
-        },
-        {
-            code: "//Copyright 2015\n//My Company\nconsole.log(1)",
-            options: ["line", ["Copyright 2015", "My Company"]]
-        },
-        {
-            code: "/*Copyright 2015\nMy Company*/\nconsole.log(1)",
-            options: ["block", ["Copyright 2015", "My Company"]]
-        },
-        {
-            code: "/*************************\n * Copyright 2015\n * My Company\n *************************/\nconsole.log(1)",
-            options: ["block", [
-                "************************",
-                " * Copyright 2015",
-                " * My Company",
-                " ************************"
-            ]]
-        },
-        {
-            code: "/*\nCopyright 2015\nMy Company\n*/\nconsole.log(1)",
-            options: ["tests/support/block.js"]
-        },
-        {
-            code: "// Copyright 2015\n// My Company\nconsole.log(1)",
-            options: ["tests/support/line.js"]
-        },
-        {
-            code: "//Copyright 2015\n//My Company\n/* DOCS */",
-            options: ["line", "Copyright 2015\nMy Company"]
-        },
-        {
-            code: "// Copyright 2017",
-            options: ["line", {pattern: "^ Copyright \\d+$"}, 0]
-        },
-        {
-            code: "// Copyright 2017\n// Author: abc@example.com",
-            options: ["line", [{pattern: "^ Copyright \\d+$"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}], 0]
-        },
-        {
-            code: "/* Copyright 2017\n Author: abc@example.com */",
-            options: ["block", {pattern: "^ Copyright \\d{4}\\n Author: \\w+@\\w+\\.\\w+ $"}, 0]
-        },
-        {
-            code: "#!/usr/bin/env node\n/**\n * Copyright\n */",
-            options: ["block", [
-                "*",
-                " * Copyright",
-                " "
-            ], 0]
-        },
-        {
-            code: "// Copyright 2015\r\n// My Company\r\nconsole.log(1)",
-            options: ["tests/support/line.js"]
-        },
-        {
-            code: "//Copyright 2018\r\n//My Company\r\n/* DOCS */",
-            options: ["line", ["Copyright 2018", "My Company"]]
-        },
-        {
-            code: "/*Copyright 2018\r\nMy Company*/\r\nconsole.log(1)",
-            options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "windows"}]
-        },
-        {
-            code: "/*Copyright 2018\nMy Company*/\nconsole.log(1)",
-            options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "unix"}]
-        },
-        {
-            code: "/*************************\n * Copyright 2015\n * My Company\n *************************/\nconsole.log(1)",
-            options: ["block", [
-                "************************",
-                { pattern: " \\* Copyright \\d{4}" },
-                " * My Company",
-                " ************************"
-            ]]
-        },
-        {
-            code: "/*Copyright 2020, My Company*/\nconsole.log(1);",
-            options: ["block", "Copyright 2020, My Company", 1],
-        },
-        {
-            code: "/*Copyright 2020, My Company*/\n\nconsole.log(1);",
-            options: ["block", "Copyright 2020, My Company", 2],
-        },
-        {
-            code: "/*Copyright 2020, My Company*/\n\n// Log number one\nconsole.log(1);",
-            options: ["block", "Copyright 2020, My Company", 2],
-        },
-        {
-            code: "/*Copyright 2020, My Company*/\n\n/*Log number one*/\nconsole.log(1);",
-            options: ["block", "Copyright 2020, My Company", 2],
-        },
-        {
-            code: "/**\n * Copyright 2020\n * My Company\n **/\n\n/*Log number one*/\nconsole.log(1);",
-            options: ["block", "*\n * Copyright 2020\n * My Company\n *", 2],
-        },
-        {
-            code: "#!/usr/bin/env node\r\n/**\r\n * Copyright\r\n */",
-            options: ["block", [
-                "*",
-                " * Copyright",
-                " "
-            ], 0]
-        }
-    ],
-    invalid: [
-        {
-            code: "console.log(1);",
-            options: ["block", "Copyright 2015, My Company"],
-            errors: [
-                {message: "missing header"}
-            ],
-            output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
-        },
-        {
-            code: "//Copyright 2014, My Company\nconsole.log(1);",
-            options: ["block", "Copyright 2015, My Company"],
-            errors: [
-                {message: "header should be a block comment"}
-            ],
-            output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
-        },
-        {
-            code: "/*Copyright 2014, My Company*/\nconsole.log(1);",
-            options: ["line", "Copyright 2015, My Company"],
-            errors: [
-                {message: "header should be a line comment"}
-            ],
-            output: "//Copyright 2015, My Company\nconsole.log(1);"
-        },
-        {
-            code: "/*Copyright 2014, My Company*/\nconsole.log(1);",
-            options: ["block", "Copyright 2015, My Company"],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
-        },
-        {
-            // Test extra line in comment
-            code: "/*Copyright 2015\nMy Company\nExtra*/\nconsole.log(1);",
-            options: ["block", ["Copyright 2015", "My Company"]],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "/*Copyright 2015\nMy Company*/\nconsole.log(1);"
-        },
-        {
-            code: "/*Copyright 2015\n*/\nconsole.log(1);",
-            options: ["block", ["Copyright 2015", "My Company"]],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "/*Copyright 2015\nMy Company*/\nconsole.log(1);"
-        },
-        {
-            code: "//Copyright 2014\n//My Company\nconsole.log(1)",
-            options: ["line", "Copyright 2015\nMy Company"],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "//Copyright 2015\n//My Company\nconsole.log(1)"
-        },
-        {
-            code: "//Copyright 2015",
-            options: ["line", "Copyright 2015\nMy Company"],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "//Copyright 2015\n//My Company\n"
-        },
-        {
-            code: "// Copyright 2017 trailing",
-            options: ["line", {pattern: "^ Copyright \\d+$"}],
-            errors: [
-                {message: "incorrect header"}
-            ]
-        },
-        {
-            code: "// Copyright 2017 trailing",
-            options: ["line", {pattern: "^ Copyright \\d+$", template: " Copyright 2018"}],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "// Copyright 2018\n"
-        },
-        {
-            code: "// Copyright 2017 trailing\n// Someone",
-            options: ["line", [{pattern: "^ Copyright \\d+$", template: " Copyright 2018"}, " My Company"]],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "// Copyright 2018\n// My Company\n"
-        },
-        {
-            code: "// Copyright 2017\n// Author: ab-c@example.com",
-            options: ["line", [{pattern: "Copyright \\d+"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}]],
-            errors: [
-                {message: "incorrect header"}
-            ]
-        },
-        {
-            code: "/* Copyright 2017-01-02\n Author: abc@example.com */",
-            options: ["block", {pattern: "^ Copyright \\d+\\n Author: \\w+@\\w+\\.\\w+ $"}],
-            errors: [
-                {message: "incorrect header"}
-            ]
-        },
-        {
-            code: "/*************************\n * Copyright 2015\n * All your base are belong to us!\n *************************/\nconsole.log(1)",
-            options: ["block", [
-                "************************",
-                { pattern: " \\* Copyright \\d{4}", template: " * Copyright 2019" },
-                " * My Company",
-                " ************************"
-            ]],
-            errors: [
-                {message: "incorrect header"}
-            ],
-            output: "/*************************\n * Copyright 2019\n * My Company\n *************************/\nconsole.log(1)"
-        },
-        {
-            code: "/*Copyright 2020, My Company*/console.log(1);",
-            options: ["block", "Copyright 2020, My Company", 2],
-            errors: [
-                {message: "no newline after header"}
-            ],
-            output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);"
-        },
-        {
-            code: "/*Copyright 2020, My Company*/console.log(1);",
-            options: ["block", "Copyright 2020, My Company", 1],
-            errors: [
-                {message: "no newline after header"}
-            ],
-            output: "/*Copyright 2020, My Company*/\nconsole.log(1);"
-        },
-        {
-            code: "//Copyright 2020\n//My Company\nconsole.log(1);",
-            options: ["line", ["Copyright 2020", "My Company"], 2],
-            errors: [
-                {message: "no newline after header"}
-            ],
-            output: "//Copyright 2020\n//My Company\n\nconsole.log(1);"
-        },
-        {
-            code: "/*Copyright 2020, My Company*/\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
-            options: ["block", "Copyright 2020, My Company", 2],
-            errors: [
-                {message: "no newline after header"}
-            ],
-            output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
-        },
-        {
-            code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
-            options: ["line", ["Copyright 2020", "My Company"], 2],
-            errors: [
-                {message: "no newline after header"}
-            ],
-            output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
-        }
-    ]
+const rule = require("../../../lib/rules/header");
+const { RuleTester } = require("eslint");
+
+const ruleTester = new RuleTester();
+
+describe("unix", () => {
+    beforeEach(() => {
+        os.EOL = "\n";
+    });
+    ruleTester.run("header", rule, {
+        valid: [
+            {
+                code: "/*Copyright 2015, My Company*/\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company"]
+            },
+            {
+                code: "//Copyright 2015, My Company\nconsole.log(1);",
+                options: ["line", "Copyright 2015, My Company"]
+            },
+            {
+                code: "/*Copyright 2015, My Company*/",
+                options: ["block", "Copyright 2015, My Company", 0]
+            },
+            {
+                code: "//Copyright 2015\n//My Company\nconsole.log(1)",
+                options: ["line", "Copyright 2015\nMy Company"]
+            },
+            {
+                code: "//Copyright 2015\n//My Company\nconsole.log(1)",
+                options: ["line", ["Copyright 2015", "My Company"]]
+            },
+            {
+                code: "/*Copyright 2015\nMy Company*/\nconsole.log(1)",
+                options: ["block", ["Copyright 2015", "My Company"]]
+            },
+            {
+                code: "/*************************\n * Copyright 2015\n * My Company\n *************************/\nconsole.log(1)",
+                options: ["block", [
+                    "************************",
+                    " * Copyright 2015",
+                    " * My Company",
+                    " ************************"
+                ]]
+            },
+            {
+                code: "/*\nCopyright 2015\nMy Company\n*/\nconsole.log(1)",
+                options: ["tests/support/block.js"]
+            },
+            {
+                code: "// Copyright 2015\n// My Company\nconsole.log(1)",
+                options: ["tests/support/line.js"]
+            },
+            {
+                code: "//Copyright 2015\n//My Company\n/* DOCS */",
+                options: ["line", "Copyright 2015\nMy Company"]
+            },
+            {
+                code: "// Copyright 2017",
+                options: ["line", {pattern: "^ Copyright \\d+$"}, 0]
+            },
+            {
+                code: "// Copyright 2017\n// Author: abc@example.com",
+                options: ["line", [{pattern: "^ Copyright \\d+$"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}], 0]
+            },
+            {
+                code: "/* Copyright 2017\n Author: abc@example.com */",
+                options: ["block", {pattern: "^ Copyright \\d{4}\\n Author: \\w+@\\w+\\.\\w+ $"}, 0]
+            },
+            {
+                code: "#!/usr/bin/env node\n/**\n * Copyright\n */",
+                options: ["block", [
+                    "*",
+                    " * Copyright",
+                    " "
+                ], 0]
+            },
+            {
+                code: "// Copyright 2015\r\n// My Company\r\nconsole.log(1)",
+                options: ["tests/support/line.js"]
+            },
+            {
+                code: "//Copyright 2018\r\n//My Company\r\n/* DOCS */",
+                options: ["line", ["Copyright 2018", "My Company"]]
+            },
+            {
+                code: "/*Copyright 2018\r\nMy Company*/\r\nconsole.log(1)",
+                options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "windows"}]
+            },
+            {
+                code: "/*Copyright 2018\nMy Company*/\nconsole.log(1)",
+                options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "unix"}]
+            },
+            {
+                code: "/*************************\n * Copyright 2015\n * My Company\n *************************/\nconsole.log(1)",
+                options: ["block", [
+                    "************************",
+                    { pattern: " \\* Copyright \\d{4}" },
+                    " * My Company",
+                    " ************************"
+                ]]
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 1],
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\n\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\n\n// Log number one\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\n\n/*Log number one*/\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+            },
+            {
+                code: "/**\n * Copyright 2020\n * My Company\n **/\n\n/*Log number one*/\nconsole.log(1);",
+                options: ["block", "*\n * Copyright 2020\n * My Company\n *", 2],
+            },
+            {
+                code: "#!/usr/bin/env node\r\n/**\r\n * Copyright\r\n */",
+                options: ["block", [
+                    "*",
+                    " * Copyright",
+                    " "
+                ], 0]
+            }
+        ],
+        invalid: [
+            {
+                code: "console.log(1);",
+                options: ["block", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014, My Company\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "header should be a block comment"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2014, My Company*/\nconsole.log(1);",
+                options: ["line", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "header should be a line comment"}
+                ],
+                output: "//Copyright 2015, My Company\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2014, My Company*/\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                // Test extra line in comment
+                code: "/*Copyright 2015\nMy Company\nExtra*/\nconsole.log(1);",
+                options: ["block", ["Copyright 2015", "My Company"]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*Copyright 2015\nMy Company*/\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2015\n*/\nconsole.log(1);",
+                options: ["block", ["Copyright 2015", "My Company"]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*Copyright 2015\nMy Company*/\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014\n//My Company\nconsole.log(1)",
+                options: ["line", "Copyright 2015\nMy Company"],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "//Copyright 2015\n//My Company\nconsole.log(1)"
+            },
+            {
+                code: "//Copyright 2015",
+                options: ["line", "Copyright 2015\nMy Company"],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "//Copyright 2015\n//My Company\n"
+            },
+            {
+                code: "// Copyright 2017 trailing",
+                options: ["line", {pattern: "^ Copyright \\d+$"}],
+                errors: [
+                    {message: "incorrect header"}
+                ]
+            },
+            {
+                code: "// Copyright 2017 trailing",
+                options: ["line", {pattern: "^ Copyright \\d+$", template: " Copyright 2018"}],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "// Copyright 2018\n"
+            },
+            {
+                code: "// Copyright 2017 trailing\n// Someone",
+                options: ["line", [{pattern: "^ Copyright \\d+$", template: " Copyright 2018"}, " My Company"]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "// Copyright 2018\n// My Company\n"
+            },
+            {
+                code: "// Copyright 2017\n// Author: ab-c@example.com",
+                options: ["line", [{pattern: "Copyright \\d+"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}]],
+                errors: [
+                    {message: "incorrect header"}
+                ]
+            },
+            {
+                code: "/* Copyright 2017-01-02\n Author: abc@example.com */",
+                options: ["block", {pattern: "^ Copyright \\d+\\n Author: \\w+@\\w+\\.\\w+ $"}],
+                errors: [
+                    {message: "incorrect header"}
+                ]
+            },
+            {
+                code: "/*************************\n * Copyright 2015\n * All your base are belong to us!\n *************************/\nconsole.log(1)",
+                options: ["block", [
+                    "************************",
+                    { pattern: " \\* Copyright \\d{4}", template: " * Copyright 2019" },
+                    " * My Company",
+                    " ************************"
+                ]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*************************\n * Copyright 2019\n * My Company\n *************************/\nconsole.log(1)"
+            },
+            {
+                code: "/*Copyright 2020, My Company*/console.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2020, My Company*/console.log(1);",
+                options: ["block", "Copyright 2020, My Company", 1],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "/*Copyright 2020, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2020\n//My Company\nconsole.log(1);",
+                options: ["line", ["Copyright 2020", "My Company"], 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\n//My Company\n\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
+                options: ["block", "Copyright 2020, My Company", 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
+            },
+            {
+                code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
+                options: ["line", ["Copyright 2020", "My Company"], 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
+            }
+        ]
+    });
 });


### PR DESCRIPTION
# Why?
Most unit invalid test cases did not pass when running under Windows because test cases expected fixes to use LF and not CR+LF.

# The Fix
Modify node's line ending property using [testdouble](https://www.npmjs.com/package/testdouble) to ensure the test cases are executed in a POSIX-compatible/simulated environment.

# Upcomming Fix
A subsequent PR will add a good representation of both POSIX and Windows in the test cases.