### PR TITLE
fix: proper emty lines on Windows

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -76,7 +76,9 @@ function genCommentBody(commentType, textArray, eol, numNewlines) {
 function genCommentsRange(context, comments, eol) {
     var start = comments[0].range[0];
     var end = comments.slice(-1)[0].range[1];
-    if (context.getSourceCode().text[end] === eol) {
+    const sourceCode = context.getSourceCode().text;
+    const headerTrailingChars = sourceCode.substring(end, end + eol.length);
+    if (headerTrailingChars === eol) {
         end += eol.length;
     }
     return [start, end];

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -168,12 +168,44 @@ describe("unix", () => {
                 output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
             },
             {
+                code: "console.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "unix" }],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "console.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "windows" }],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
+            },
+            {
                 code: "//Copyright 2014, My Company\nconsole.log(1);",
                 options: ["block", "Copyright 2015, My Company"],
                 errors: [
                     {message: "header should be a block comment"}
                 ],
                 output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014, My Company\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "unix" }],
+                errors: [
+                    {message: "header should be a block comment"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014, My Company\r\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "windows" }],
+                errors: [
+                    {message: "header should be a block comment"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
             },
             {
                 code: "/*Copyright 2014, My Company*/\nconsole.log(1);",
@@ -308,6 +340,23 @@ describe("unix", () => {
             },
             {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
+                options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "unix"}],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
+            },
+            {
+                name: "Missing empty line after header / windows",
+                code: "//Copyright 2020\r\n//My Company\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
+                options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "windows"}],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\r\n//My Company\r\n\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment"
+            },
+            {
+                code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: ["line", ["Copyright 2020", "My Company"], 2],
                 errors: [
                     {message: "no newline after header"}
@@ -317,3 +366,336 @@ describe("unix", () => {
         ]
     });
 });
+describe("windows", () => {
+    beforeEach(() => {
+        os.EOL = "\r\n";
+    });
+    ruleTester.run("header", rule, {
+        valid: [
+            {
+                code: "/*Copyright 2015, My Company*/\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company"]
+            },
+            {
+                code: "//Copyright 2015, My Company\nconsole.log(1);",
+                options: ["line", "Copyright 2015, My Company"]
+            },
+            {
+                code: "/*Copyright 2015, My Company*/",
+                options: ["block", "Copyright 2015, My Company", 0]
+            },
+            {
+                code: "//Copyright 2015\n//My Company\nconsole.log(1)",
+                options: ["line", "Copyright 2015\nMy Company"]
+            },
+            {
+                code: "//Copyright 2015\n//My Company\nconsole.log(1)",
+                options: ["line", ["Copyright 2015", "My Company"]]
+            },
+            {
+                code: "/*Copyright 2015\nMy Company*/\nconsole.log(1)",
+                options: ["block", ["Copyright 2015", "My Company"]]
+            },
+            {
+                code: "/*************************\n * Copyright 2015\n * My Company\n *************************/\nconsole.log(1)",
+                options: ["block", [
+                    "************************",
+                    " * Copyright 2015",
+                    " * My Company",
+                    " ************************"
+                ]]
+            },
+            {
+                code: "/*\nCopyright 2015\nMy Company\n*/\nconsole.log(1)",
+                options: ["tests/support/block.js"]
+            },
+            {
+                code: "// Copyright 2015\n// My Company\nconsole.log(1)",
+                options: ["tests/support/line.js"]
+            },
+            {
+                code: "//Copyright 2015\n//My Company\n/* DOCS */",
+                options: ["line", "Copyright 2015\nMy Company"]
+            },
+            {
+                code: "// Copyright 2017",
+                options: ["line", {pattern: "^ Copyright \\d+$"}, 0]
+            },
+            {
+                code: "// Copyright 2017\n// Author: abc@example.com",
+                options: ["line", [{pattern: "^ Copyright \\d+$"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}], 0]
+            },
+            {
+                code: "/* Copyright 2017\n Author: abc@example.com */",
+                options: ["block", {pattern: "^ Copyright \\d{4}\\n Author: \\w+@\\w+\\.\\w+ $"}, 0]
+            },
+            {
+                code: "#!/usr/bin/env node\n/**\n * Copyright\n */",
+                options: ["block", [
+                    "*",
+                    " * Copyright",
+                    " "
+                ], 0]
+            },
+            {
+                code: "// Copyright 2015\r\n// My Company\r\nconsole.log(1)",
+                options: ["tests/support/line.js"]
+            },
+            {
+                code: "//Copyright 2018\r\n//My Company\r\n/* DOCS */",
+                options: ["line", ["Copyright 2018", "My Company"]]
+            },
+            {
+                code: "/*Copyright 2018\r\nMy Company*/\r\nconsole.log(1)",
+                options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "windows"}]
+            },
+            {
+                code: "/*Copyright 2018\nMy Company*/\nconsole.log(1)",
+                options: ["block", ["Copyright 2018", "My Company"], {"lineEndings": "unix"}]
+            },
+            {
+                code: "/*************************\n * Copyright 2015\n * My Company\n *************************/\nconsole.log(1)",
+                options: ["block", [
+                    "************************",
+                    { pattern: " \\* Copyright \\d{4}" },
+                    " * My Company",
+                    " ************************"
+                ]]
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 1],
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\n\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\n\n// Log number one\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\n\n/*Log number one*/\nconsole.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+            },
+            {
+                code: "/**\n * Copyright 2020\n * My Company\n **/\n\n/*Log number one*/\nconsole.log(1);",
+                options: ["block", "*\n * Copyright 2020\n * My Company\n *", 2],
+            },
+            {
+                code: "#!/usr/bin/env node\r\n/**\r\n * Copyright\r\n */",
+                options: ["block", [
+                    "*",
+                    " * Copyright",
+                    " "
+                ], 0]
+            }
+        ],
+        invalid: [
+            {
+                code: "console.log(1);",
+                options: ["block", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "console.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "unix" }],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "console.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "windows" }],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014, My Company\r\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "header should be a block comment"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014, My Company\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "unix" }],
+                errors: [
+                    {message: "header should be a block comment"}
+                ],
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014, My Company\r\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company", { lineEndings: "windows" }],
+                errors: [
+                    {message: "header should be a block comment"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2014, My Company*/\r\nconsole.log(1);",
+                options: ["line", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "header should be a line comment"}
+                ],
+                output: "//Copyright 2015, My Company\r\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2014, My Company*/\r\nconsole.log(1);",
+                options: ["block", "Copyright 2015, My Company"],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*Copyright 2015, My Company*/\r\nconsole.log(1);"
+            },
+            {
+                // Test extra line in comment
+                code: "/*Copyright 2015\r\nMy Company\r\nExtra*/\r\nconsole.log(1);",
+                options: ["block", ["Copyright 2015", "My Company"]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*Copyright 2015\r\nMy Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2015\r\n*/\r\nconsole.log(1);",
+                options: ["block", ["Copyright 2015", "My Company"]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*Copyright 2015\r\nMy Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2014\r\n//My Company\r\nconsole.log(1)",
+                options: ["line", "Copyright 2015\r\nMy Company"],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "//Copyright 2015\r\n//My Company\r\nconsole.log(1)"
+            },
+            {
+                code: "//Copyright 2015",
+                options: ["line", "Copyright 2015\r\nMy Company"],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "//Copyright 2015\r\n//My Company\r\n"
+            },
+            {
+                code: "// Copyright 2017 trailing",
+                options: ["line", {pattern: "^ Copyright \\d+$"}],
+                errors: [
+                    {message: "incorrect header"}
+                ]
+            },
+            {
+                code: "// Copyright 2017 trailing",
+                options: ["line", {pattern: "^ Copyright \\d+$", template: " Copyright 2018"}],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "// Copyright 2018\r\n"
+            },
+            {
+                code: "// Copyright 2017 trailing\r\n// Someone",
+                options: ["line", [{pattern: "^ Copyright \\d+$", template: " Copyright 2018"}, " My Company"]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "// Copyright 2018\r\n// My Company\r\n"
+            },
+            {
+                code: "// Copyright 2017\r\n// Author: ab-c@example.com",
+                options: ["line", [{pattern: "Copyright \\d+"}, {pattern: "^ Author: \\w+@\\w+\\.\\w+$"}]],
+                errors: [
+                    {message: "incorrect header"}
+                ]
+            },
+            {
+                code: "/* Copyright 2017-01-02\r\n Author: abc@example.com */",
+                options: ["block", {pattern: "^ Copyright \\d+\\r\\n Author: \\w+@\\w+\\.\\w+ $"}],
+                errors: [
+                    {message: "incorrect header"}
+                ]
+            },
+            {
+                code: "/*************************\r\n * Copyright 2015\r\n * All your base are belong to us!\r\n *************************/\r\nconsole.log(1)",
+                options: ["block", [
+                    "************************",
+                    { pattern: " \\* Copyright \\d{4}", template: " * Copyright 2019" },
+                    " * My Company",
+                    " ************************"
+                ]],
+                errors: [
+                    {message: "incorrect header"}
+                ],
+                output: "/*************************\r\n * Copyright 2019\r\n * My Company\r\n *************************/\r\nconsole.log(1)"
+            },
+            {
+                code: "/*Copyright 2020, My Company*/console.log(1);",
+                options: ["block", "Copyright 2020, My Company", 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "/*Copyright 2020, My Company*/\r\n\r\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2020, My Company*/console.log(1);",
+                options: ["block", "Copyright 2020, My Company", 1],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "/*Copyright 2020, My Company*/\r\nconsole.log(1);"
+            },
+            {
+                code: "//Copyright 2020\r\n//My Company\r\nconsole.log(1);",
+                options: ["line", ["Copyright 2020", "My Company"], 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\r\n//My Company\r\n\r\nconsole.log(1);"
+            },
+            {
+                code: "/*Copyright 2020, My Company*/\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
+                options: ["block", "Copyright 2020, My Company", 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "/*Copyright 2020, My Company*/\r\n\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment"
+            },
+            {
+                code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
+                options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "unix"}],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
+            },
+            {
+                code: "//Copyright 2020\r\n//My Company\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
+                options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "windows"}],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\r\n//My Company\r\n\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment"
+            },
+            {
+                code: "//Copyright 2020\r\n//My Company\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
+                options: ["line", ["Copyright 2020", "My Company"], 2],
+                errors: [
+                    {message: "no newline after header"}
+                ],
+                output: "//Copyright 2020\r\n//My Company\r\n\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment"
+            }
+        ]
+    });
+});
+


### PR DESCRIPTION
# The Problem
There was a bug in `genCommentsRange()` where only one character is checked after the comment for an EOL character. Since on Windows we need two characters, the check failed and the wrong number of empty lines was added on windows (desired+1) which caused both tests to fail and the autofix to give different results from POSIX.

# The Fix
_N_ number of characters are tested, where _N_ is the length of the current EOL string.

Added Windows-EOL test suite to prevent the behavior from regressing. The suite should run on both Windows dev boxes and POSIX CI/CD.