### PR TITLE
refactor: internal structured rule config

### DIFF
--- a/lib/comment-parser.js
+++ b/lib/comment-parser.js
@@ -40,12 +40,10 @@ module.exports = function commentParser(commentText) {
     if (text.startsWith("//")) {
         return [
             "line",
-            text.split(/\r?\n/).map(function(line) {
-                return line.substr(2);
-            })
+            text.split(/\r?\n/).map((line) => line.substring(2))
         ];
     } else if (text.startsWith("/*") && text.endsWith("*/")) {
-        return ["block", text.substring(2, text.length - 2)];
+        return ["block", text.substring(2, text.length - 2).split(/\r?\n/)];
     } else {
         throw new Error(
             "Could not parse comment file: the file must contain either just " +

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -41,8 +41,9 @@
  * @enum {string}
  */
 const lineEndingOptions = Object.freeze({
-    unix: "unix", // \n
-    windows: "windows", // \n
+    os: "os",
+    unix: "unix",
+    windows: "windows",
 });
 
 /**
@@ -55,22 +56,45 @@ const commentTypeOptions = Object.freeze({
 
 /**
  * Local type defintions.
- * @typedef {string | { pattern: string, template?: string }} HeaderLine
- * @typedef {HeaderLine | HeaderLine[]} HeaderLines
- * @typedef {{ lineEndings: ('unix' | 'windows') }} HeaderSettings
+ * @typedef {{ pattern: string, template?: string }} HeaderLinePattern
+ * @typedef {string | HeaderLinePattern} HeaderLine
+ * @typedef {(HeaderLine | HeaderLine[])} HeaderLines
+ * @typedef {{ lineEndings?: ('unix' | 'windows' | 'os') }} HeaderSettings
  * @typedef {
- * [string]
+ *  [string]
  *  | [string, HeaderSettings]
- *  | [('block' | 'line') | HeaderLines ]
- *  | [('block' | 'line') | HeaderLines | HeaderSettings]
- *  | [('block' | 'line') | HeaderLines | number ]
- *  | [('block' | 'line') | HeaderLines | number | HeaderSettings]
- * } HeaderOptions
+ *  | [('block' | 'line'), HeaderLines ]
+ *  | [('block' | 'line'), HeaderLines, HeaderSettings]
+ *  | [('block' | 'line'), HeaderLines, number ]
+ *  | [('block' | 'line'), HeaderLines, number, HeaderSettings]
+ * } LegacyHeaderOptions
+ * @typedef {
+ *  {
+ *      file: string,
+ *      encoding?: string
+ *  }
+ * } FileBasedConfig
+ * @typedef {
+ *  {
+ *      commentType: 'line' | 'block',
+ *      lines: HeaderLine[]
+ *  }
+ * } LinesBasedConfig
+ * @typedef {{ minimum?: number }} TrailingEmptyLines
+ * @typedef {
+ *  {
+ *      header: FileBasedConfig | LinesBasedConfig,
+ *      trailingEmptyLines?: TrailingEmptyLines
+ *  }
+ *  & HeaderSettings
+ * } NewHeaderOptions
+ * @typedef {LegacyHeaderOptions | [NewHeaderOptions]} HeaderOptions
  */
 
+const assert = require("assert");
 const fs = require("fs");
-const commentParser = require("../comment-parser");
 const os = require("os");
+const commentParser = require("../comment-parser");
 
 /**
  * Tests if the passed line configuration string or object is a pattern
@@ -222,38 +246,24 @@ function genReplaceFixer(commentType, context, leadingComments, headerLines, eol
 }
 
 /**
- * Finds the option parameter within the list of rule config options.
- * @param {HeaderOptions} options the config options passed to the rule.
- * @returns {HeaderSettings | null} the settings parameter or `null` if no such
- *                                  is defined.
- */
-function findSettings(options) {
-    const lastOption = options[options.length - 1];
-    if (typeof lastOption === "object" && !Array.isArray(lastOption) && lastOption !== null
-        && !Object.prototype.hasOwnProperty.call(lastOption, "pattern")) {
-        return lastOption;
-    }
-    return null;
-}
-
-/**
  * Returns the used line-termination characters per the rule's config if any or
  * else based on the runtime environments.
- * @param {HeaderOptions} options rule configuration.
+ * @param {'os' | 'unix' | 'windows'} style line-ending styles.
  * @returns {'\n' | '\r\n'} the correct line ending characters for the
  *                          environment.
  */
-function getEOL(options) {
-    const settings = findSettings(options);
-    if (settings) {
-        if (settings.lineEndings === lineEndingOptions.unix) {
+function getEol(style) {
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(lineEndingOptions, style), true,
+        "lineEnding style should have been populated in normalizeOptions().");
+    switch (style) {
+        case lineEndingOptions.unix:
             return "\n";
-        }
-        if (settings.lineEndings === lineEndingOptions.windows) {
+        case lineEndingOptions.windows:
             return "\r\n";
-        }
+        case lineEndingOptions.os:
+        default:
+            return os.EOL;
     }
-    return os.EOL;
 }
 
 /**
@@ -275,7 +285,7 @@ function hasHeader(src) {
  *                    the end or `false` otherwise.
  */
 function matchesLineEndings(src, num) {
-    for (let i = 0; i < num; ++i) {
+    for (let i = 0; i < num; i++) {
         const m = src.match(/^(\r\n|\r|\n)/);
         if (m) {
             src = src.slice(m.index + m[0].length);
@@ -284,6 +294,118 @@ function matchesLineEndings(src, num) {
         }
     }
     return true;
+}
+
+/**
+ * asserts on an expression and adds template texts to the failure message.
+ * Helper to write cleaner code.
+ * @param {boolean} condition assert condition.
+ * @param {string} message assert message on violation.
+ */
+function schemaAssert(condition, message) {
+    assert.strictEqual(condition, true, message + " - should have been handled by eslint schema validation.");
+}
+
+/**
+ * Ensures that if legacy options as defined in the original
+ * `eslint-plugin-header` are used, they'd be converted to the new object-based
+ * configuration. This is not a normalized internal representation of the
+ * options in that some settings are still union types and unspecified
+ * properties are not replaced by defaults. If the options follow the new
+ * format, a simple seep copy would be returned.
+ * @param {HeaderOptions} originalOptions the options as configured by the user.
+ * @returns {NewHeaderOptions} the transformed new-style options with no
+ *                             normalization.
+ */
+function transformLegacyOptions(originalOptions) {
+    schemaAssert(originalOptions?.length > 0,
+        "header options are required (at least one in addition to the severity)");
+    schemaAssert(originalOptions.length <= 4,
+        "header options should not be more than four (five including issue severity)");
+    if (originalOptions.length === 1 && typeof originalOptions[0] === "object") {
+        // The user chose to use the new-style config. We pass a copy of the
+        // incoming sole option to not mess with ESLint not relying on the old
+        // values of the option.
+        return structuredClone(originalOptions[0]);
+    }
+    // The user chose the legacy-style config. Transform them to new-style
+    // config.
+    schemaAssert(typeof originalOptions[0] === "string",
+        "first header option after severity should be either a filename or 'block' | 'line'");
+    /** @type {NewHeaderOptions} */
+    const transformedOptions = {};
+    // populate header
+    if (
+        originalOptions.length === 1
+        || (
+            originalOptions.length === 2
+            && typeof originalOptions[1] === "object"
+            && !Array.isArray(originalOptions[1])
+            && !isPattern(originalOptions[1])
+        )) {
+        transformedOptions.header = { file: originalOptions[0], encoding: "utf8" };
+    } else {
+        schemaAssert(Object.prototype.hasOwnProperty.call(commentTypeOptions, originalOptions[0]),
+            "Only 'block' or 'line' is accepted as comment type");
+        schemaAssert(
+            typeof originalOptions[1] === "string"
+            || Array.isArray(originalOptions[1])
+            || isPattern(originalOptions[1]),
+            "second header option after severity should be a string, a pattern, or an array of the previous two");
+        transformedOptions.header = {
+            commentType: originalOptions[0],
+            lines: Array.isArray(originalOptions[1]) ? originalOptions[1] : [originalOptions[1]]
+        };
+    }
+    // configure required line settings
+    if (originalOptions.length >= 3) {
+        if (typeof originalOptions[2] === "number") {
+            transformedOptions.trailingEmptyLines = { minimum: originalOptions[2] };
+            if (originalOptions.length === 4) {
+                schemaAssert(typeof originalOptions[3] === "object",
+                    "Fourth header option after severity should be either number of required trailing empty lines or " +
+                    "a settings object");
+                Object.assign(transformedOptions, originalOptions[3]);
+            }
+        } else {
+            schemaAssert(typeof originalOptions[2] === "object",
+                "Third header option after severity should be either number of required trailing empty lines or a " +
+                "settings object");
+            Object.assign(transformedOptions, originalOptions[2]);
+        }
+    }
+    return transformedOptions;
+}
+
+/**
+ * Transforms a set of new-style options adding defaults and standardizing on
+ * one of multiple config styles.
+ * @param {NewHeaderOptions} originalOptions new-style options to normalize.
+ * @returns {NewHeaderOptions} normalized options.
+ */
+function normalizeOptions(originalOptions) {
+    const options = structuredClone(originalOptions);
+
+    if (Object.prototype.hasOwnProperty.call(options.header, "file")) {
+        const text = fs.readFileSync(originalOptions.header.file, originalOptions.header.encoding);
+        const [commentType, lines] = commentParser(text);
+        options.header = { commentType, lines };
+    }
+
+    options.header.lines = options.header.lines.flatMap(
+        (line) => typeof line === "string" ? line.split(/\r?\n/) : [line]);
+
+    if (!options.lineEndings) {
+        options.lineEndings = "os";
+    }
+
+    if (!options.trailingEmptyLines) {
+        options.trailingEmptyLines = {};
+    }
+    if (typeof options.trailingEmptyLines.minimum !== "number") {
+        options.trailingEmptyLines.minimum = 1;
+    }
+    return options;
 }
 
 module.exports = {
@@ -295,7 +417,8 @@ module.exports = {
             definitions: {
                 commentType: {
                     type: "string",
-                    enum: [commentTypeOptions.block, commentTypeOptions.line]
+                    enum: [commentTypeOptions.block, commentTypeOptions.line],
+                    description: "Type of comment to expect as the header."
                 },
                 line: {
                     anyOf: [
@@ -334,18 +457,95 @@ module.exports = {
                     type: "integer",
                     minimum: 0
                 },
+                lineEndings: {
+                    type: "string",
+                    enum: [lineEndingOptions.unix, lineEndingOptions.windows, lineEndingOptions.os],
+                    description: "Line endings to use when aut-fixing the violations. Defaults to 'os' which " +
+                        "means 'same as system'."
+                    // NOTE: default value not supported by the ajv schema
+                    //       validator.
+                },
                 settings: {
                     type: "object",
                     properties: {
-                        lineEndings: {
-                            type: "string",
-                            enum: [lineEndingOptions.unix, lineEndingOptions.windows]
-                        }
+                        lineEndings: { $ref: "#/definitions/lineEndings" },
                     },
                     additionalProperties: false
                 },
+                fileBasedHeader: {
+                    type: "object",
+                    properties: {
+                        file: {
+                            type: "string",
+                            description: "Name of a file relative to the current directory (no back-tracking) that " +
+                                "contains the header template. It should contain a single block comment or a " +
+                                "contiguous number of line comments."
+                        },
+                        encoding: {
+                            type: "string",
+                            description: "Character encoding to use when parsing the file. Valid values are all " +
+                                "encodings that can be passed to `fs.readFileSync()`. If not specified, 'utf8' " +
+                                "would be used."
+                            // NOTE: default value not supported by the ajv
+                            //       schema validator.
+                        }
+                    },
+                    required: ["file"],
+                    additionalProperties: false
+                },
+                inlineHeader: {
+                    type: "object",
+                    properties: {
+                        commentType: { $ref: "#/definitions/commentType" },
+                        lines: {
+                            type: "array",
+                            items: {
+                                $ref: "#/definitions/line"
+                            },
+                            description: "List of each line of the header - each being a string to match exactly or " +
+                                "a combination of a regex pattern to match and an optional template string as the fix."
+                        }
+                    },
+                    required: ["commentType", "lines"],
+                    additionalProperties: false
+                },
+                trailingEmptyLines: {
+                    type: "object",
+                    properties: {
+                        minimimum: {
+                            type: "number",
+                            description: "Number of empty lines required after the header. Defaults to 1.",
+                            // NOTE: default value not supported by the ajv
+                            //       schema validator.
+                        }
+                    },
+                    additionalProperties: false,
+                    description: "Configuration for how to validate and fix the set of empty lines after the header."
+                },
+                newOptions: {
+                    type: "object",
+                    properties: {
+                        header: {
+                            anyOf: [
+                                { $ref: "#/definitions/fileBasedHeader"},
+                                { $ref: "#/definitions/inlineHeader"}
+                            ]
+                        },
+                        lineEndings: { $ref: "#/definitions/lineEndings" },
+                        trailingEmptyLines: { $ref: "#/definitions/trailingEmptyLines" }
+                    },
+                    required: ["header"],
+                    additionalProperties: false,
+                    description: "Object-based extensible configuration format to use with the `header` rule."
+                },
                 options: {
                     anyOf: [
+                        {
+                            type: "array",
+                            minItems: 1,
+                            maxItems: 1,
+                            items: { $ref: "#/definitions/newOptions" }
+                        },
                         {
                             type: "array",
                             minItems: 1,
@@ -387,45 +587,26 @@ module.exports = {
      * @returns {NodeListener} the rule definition.
      */
     create: function(context) {
-        let options = context.options;
-        const numNewlines = options.length > 2 && typeof options[2] === "number" ? options[2] : 1;
-        const eol = getEOL(options);
 
-        // If just one option then read comment from file
-        if (options.length === 1 || (options.length === 2 && findSettings(options))) {
-            const text = fs.readFileSync(context.options[0], "utf8");
-            options = commentParser(text);
-        }
+        const newStyleOptions = transformLegacyOptions(context.options);
+        const options = normalizeOptions(newStyleOptions);
 
-        const commentType = options[0].toLowerCase();
-        let headerLines;
+        const eol = getEol(options.lineEndings);
+
         let fixLines = [];
         // If any of the lines are regular expressions, then we can't
         // automatically fix them. We set this to true below once we
         // ensure none of the lines are of type RegExp
-        let canFix = false;
-        if (Array.isArray(options[1])) {
-            canFix = true;
-            headerLines = options[1].map(function(line) {
-                const isRegex = isPattern(line);
-                // Can only fix regex option if a template is also provided
-                if (isRegex && !line.template) {
-                    canFix = false;
-                }
-                fixLines.push(line.template || line);
-                return isRegex ? new RegExp(line.pattern) : line;
-            });
-        } else if (isPattern(options[1])) {
-            const line = options[1];
-            headerLines = [new RegExp(line.pattern)];
+        let canFix = true;
+        const headerLines = options.header.lines.map(function(line) {
+            const isRegex = isPattern(line);
+            // Can only fix regex option if a template is also provided
+            if (isRegex && !line.template) {
+                canFix = false;
+            }
             fixLines.push(line.template || line);
-            // Same as above for regex and template
-            canFix = !!line.template;
-        } else {
-            canFix = true;
-            headerLines = options[1].split(/\r?\n/);
-            fixLines = headerLines;
-        }
+            return isRegex ? new RegExp(line.pattern) : line;
+        });
 
         return {
             /**
@@ -439,36 +620,47 @@ module.exports = {
                     context.report({
                         loc: node.loc,
                         message: "missing header",
-                        fix: genPrependFixer(commentType, context, fixLines, eol, numNewlines)
+                        fix: genPrependFixer(
+                            options.header.commentType,
+                            context,
+                            fixLines,
+                            eol,
+                            options.trailingEmptyLines.minimum)
                     });
                 } else {
                     const leadingComments = getLeadingComments(context, node);
 
-                    if (leadingComments[0].type.toLowerCase() !== commentType) {
+                    if (leadingComments[0].type.toLowerCase() !== options.header.commentType) {
                         context.report({
                             loc: node.loc,
                             message: "header should be a {{commentType}} comment",
                             data: {
-                                commentType: commentType
+                                commentType: options.header.commentType
                             },
                             fix: canFix
-                                ? genReplaceFixer(commentType, context, leadingComments, fixLines, eol, numNewlines)
+                                ? genReplaceFixer(
+                                    options.header.commentType,
+                                    context,
+                                    leadingComments,
+                                    fixLines,
+                                    eol,
+                                    options.trailingEmptyLines.minimum)
                                 : null
                         });
                     } else {
-                        if (commentType === commentTypeOptions.line) {
+                        if (options.header.commentType === commentTypeOptions.line) {
                             if (leadingComments.length < headerLines.length) {
                                 context.report({
                                     loc: node.loc,
                                     message: "incorrect header",
                                     fix: canFix
                                         ? genReplaceFixer(
-                                            commentType,
+                                            options.header.commentType,
                                             context,
                                             leadingComments,
                                             fixLines,
                                             eol,
-                                            numNewlines)
+                                            options.trailingEmptyLines.minimum)
                                         : null
                                 });
                                 return;
@@ -480,12 +672,12 @@ module.exports = {
                                         message: "incorrect header",
                                         fix: canFix
                                             ? genReplaceFixer(
-                                                commentType,
+                                                options.header.commentType,
                                                 context,
                                                 leadingComments,
                                                 fixLines,
                                                 eol,
-                                                numNewlines)
+                                                options.trailingEmptyLines.minimum)
                                             : null
                                     });
                                     return;
@@ -493,19 +685,21 @@ module.exports = {
                             }
 
                             const start = leadingComments[headerLines.length - 1].range[1];
-                            const postLineHeader = context.sourceCode.text.substring(start, start + numNewlines * 2);
-                            if (!matchesLineEndings(postLineHeader, numNewlines)) {
+                            const postLineHeader = context.sourceCode.text.substring(
+                                start,
+                                start + options.trailingEmptyLines.minimum * 2);
+                            if (!matchesLineEndings(postLineHeader, options.trailingEmptyLines.minimum)) {
                                 context.report({
                                     loc: node.loc,
                                     message: "no newline after header",
                                     fix: canFix
                                         ? genReplaceFixer(
-                                            commentType,
+                                            options.header.commentType,
                                             context,
                                             leadingComments,
                                             fixLines,
                                             eol,
-                                            numNewlines)
+                                            options.trailingEmptyLines.minimum)
                                         : null
                                 });
                             }
@@ -540,30 +734,31 @@ module.exports = {
                                     message: "incorrect header",
                                     fix: canFix
                                         ? genReplaceFixer(
-                                            commentType,
+                                            options.header.commentType,
                                             context,
                                             leadingComments,
                                             fixLines,
                                             eol,
-                                            numNewlines)
+                                            options.trailingEmptyLines.minimum)
                                         : null
                                 });
                             } else {
                                 const start = leadingComments[0].range[1];
-                                const postBlockHeader =
-                                    context.sourceCode.text.substring(start, start + numNewlines * 2);
-                                if (!matchesLineEndings(postBlockHeader, numNewlines)) {
+                                const postBlockHeader = context.sourceCode.text.substring(
+                                    start,
+                                    start + options.trailingEmptyLines.minimum * 2);
+                                if (!matchesLineEndings(postBlockHeader, options.trailingEmptyLines.minimum)) {
                                     context.report({
                                         loc: node.loc,
                                         message: "no newline after header",
                                         fix: canFix
                                             ? genReplaceFixer(
-                                                commentType,
+                                                options.header.commentType,
                                                 context,
                                                 leadingComments,
                                                 fixLines,
                                                 eol,
-                                                numNewlines)
+                                                options.trailingEmptyLines.minimum)
                                             : null
                                     });
                                 }
@@ -575,3 +770,4 @@ module.exports = {
         };
     }
 };
+

--- a/tests/lib/comment-parser-test.js
+++ b/tests/lib/comment-parser-test.js
@@ -31,7 +31,7 @@ const commentParser = require("../../lib/comment-parser");
 describe("comment parser", function() {
     it("parses block comments", function() {
         const result = commentParser("/* pass1\n pass2 */  ");
-        assert.deepEqual(result, ["block", " pass1\n pass2 "]);
+        assert.deepEqual(result, ["block", [" pass1", " pass2 "]]);
     });
 
     it("throws an error when a block comment isn't ended", function() {

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -45,6 +45,15 @@ describe("unix", () => {
                 options: ["block", "Copyright 2015, My Company"]
             },
             {
+                code: "/*Copyright 2015, My Company*/\nconsole.log(1);",
+                options: [{
+                    header: {
+                        commentType: "block",
+                        lines: ["Copyright 2015, My Company"]
+                    }
+                }]
+            },
+            {
                 code: "//Copyright 2015, My Company\nconsole.log(1);",
                 options: ["line", "Copyright 2015, My Company"]
             },


### PR DESCRIPTION
Introducing a new rule configuration format. It contains of a single JS objct definiing all aspects of the linting.

Original array configuration made sense when capabilities of the plugin were rather limited - or rather - opinionated. As consumers and contributors were adding more features, the quality of the configuration using the format started deteriorating. Parsing the array is quite annoying and opens oprotunities for bugs such as the one fixed by #2.

The new format would not be documented at the moment and advertized to consumers until the code reaches a certain threshold of maturity. In the mean time it would be used as the internal format of the parsed configuration and tests would be gradually migrated to it.

The changes add st one new test for the new config to guaratee 100% coverage. To support the test case I had to add the new config's schema to the overal rule config.