### PR TITLE
fix: support matching multi-line line comments with a single pattern - fixes #37

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -446,6 +446,17 @@ module.exports = {
                                 });
                                 return;
                             }
+                            if (headerLines.length === 1) {
+                                const leadingCommentValues = leadingComments.map((c) => c.value);
+                                if (!match(leadingCommentValues.join("\n"), headerLines[0]) && !match(leadingCommentValues.join("\r\n"), headerLines[0])) {
+                                    context.report({
+                                        loc: node.loc,
+                                        message: "incorrect header",
+                                        fix: canFix ? genReplaceFixer(commentType, context, leadingComments, fixLines, eol, numNewlines) : null
+                                    });
+                                }
+                                return;
+                            }
                             for (var i = 0; i < headerLines.length; i++) {
                                 if (!match(leadingComments[i].value, headerLines[i])) {
                                     context.report({

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -70,6 +70,10 @@ describe("unix", () => {
             },
             {
                 code: "// Copyright (c) 2015\n// My Company\n",
+                options: ["line", { pattern: " Copyright \\(c\\) 2015\\n My Company" }]
+            },
+            {
+                code: "// Copyright (c) 2015\n// My Company\n",
                 options: ["line", [{ pattern: " Copyright \\(c\\) 2015" }, " My Company"]]
             },
             {


### PR DESCRIPTION
When line comments are used the plugin expected to every line to have a corresponding line string or pattern.

The fix is if there is a single string to test against it by joining the lines of the comment with either POSIX or Windows EOL.