### PR TITLE
refactor: improve code quality

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -24,6 +24,12 @@
 
 "use strict";
 
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const { lineEndingOptions, commentTypeOptions, schema } = require("./header.schema");
+const commentParser = require("../comment-parser");
+
 /**
  * Import type definitions.
  * @typedef {import('estree').Comment} Comment
@@ -36,23 +42,6 @@
  * @typedef {import('eslint').Rule.RuleTextEditor} RuleTextEditor
  * @typedef {import('eslint').Rule.RuleContext} RuleContext
  */
-
-/**
- * @enum {string}
- */
-const lineEndingOptions = Object.freeze({
-    os: "os",
-    unix: "unix",
-    windows: "windows",
-});
-
-/**
- * @enum {string}
- */
-const commentTypeOptions = Object.freeze({
-    block: "block",
-    line: "line"
-});
 
 /**
  * Local type defintions.
@@ -90,11 +79,6 @@ const commentTypeOptions = Object.freeze({
  * } NewHeaderOptions
  * @typedef {LegacyHeaderOptions | [NewHeaderOptions]} HeaderOptions
  */
-
-const assert = require("assert");
-const fs = require("fs");
-const os = require("os");
-const commentParser = require("../comment-parser");
 
 /**
  * Tests if the passed line configuration string or object is a pattern
@@ -412,174 +396,7 @@ module.exports = {
     meta: {
         type: "layout",
         fixable: "whitespace",
-        schema: {
-            $ref: "#/definitions/options",
-            definitions: {
-                commentType: {
-                    type: "string",
-                    enum: [commentTypeOptions.block, commentTypeOptions.line],
-                    description: "Type of comment to expect as the header."
-                },
-                line: {
-                    anyOf: [
-                        {
-                            type: "string"
-                        },
-                        {
-                            type: "object",
-                            properties: {
-                                pattern: {
-                                    type: "string"
-                                },
-                                template: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["pattern"],
-                            additionalProperties: false
-                        }
-                    ]
-                },
-                headerLines: {
-                    anyOf: [
-                        {
-                            $ref: "#/definitions/line"
-                        },
-                        {
-                            type: "array",
-                            items: {
-                                $ref: "#/definitions/line"
-                            }
-                        }
-                    ]
-                },
-                numNewlines: {
-                    type: "integer",
-                    minimum: 0
-                },
-                lineEndings: {
-                    type: "string",
-                    enum: [lineEndingOptions.unix, lineEndingOptions.windows, lineEndingOptions.os],
-                    description: "Line endings to use when aut-fixing the violations. Defaults to 'os' which " +
-                        "means 'same as system'."
-                    // NOTE: default value not supported by the ajv schema
-                    //       validator.
-                },
-                settings: {
-                    type: "object",
-                    properties: {
-                        lineEndings: { $ref: "#/definitions/lineEndings" },
-                    },
-                    additionalProperties: false
-                },
-                fileBasedHeader: {
-                    type: "object",
-                    properties: {
-                        file: {
-                            type: "string",
-                            description: "Name of a file relative to the current directory (no back-tracking) that " +
-                                "contains the header template. It should contain a single block comment or a " +
-                                "contiguous number of line comments."
-                        },
-                        encoding: {
-                            type: "string",
-                            description: "Character encoding to use when parsing the file. Valid values are all " +
-                                "encodings that can be passed to `fs.readFileSync()`. If not specified, 'utf8' " +
-                                "would be used."
-                            // NOTE: default value not supported by the ajv
-                            //       schema validator.
-                        }
-                    },
-                    required: ["file"],
-                    additionalProperties: false
-                },
-                inlineHeader: {
-                    type: "object",
-                    properties: {
-                        commentType: { $ref: "#/definitions/commentType" },
-                        lines: {
-                            type: "array",
-                            items: {
-                                $ref: "#/definitions/line"
-                            },
-                            description: "List of each line of the header - each being a string to match exactly or " +
-                                "a combination of a regex pattern to match and an optional template string as the fix."
-                        }
-                    },
-                    required: ["commentType", "lines"],
-                    additionalProperties: false
-                },
-                trailingEmptyLines: {
-                    type: "object",
-                    properties: {
-                        minimum: {
-                            type: "number",
-                            description: "Number of empty lines required after the header. Defaults to 1.",
-                            // NOTE: default value not supported by the ajv
-                            //       schema validator.
-                        }
-                    },
-                    additionalProperties: false,
-                    description: "Configuration for how to validate and fix the set of empty lines after the header."
-                },
-                newOptions: {
-                    type: "object",
-                    properties: {
-                        header: {
-                            anyOf: [
-                                { $ref: "#/definitions/fileBasedHeader"},
-                                { $ref: "#/definitions/inlineHeader"}
-                            ]
-                        },
-                        lineEndings: { $ref: "#/definitions/lineEndings" },
-                        trailingEmptyLines: { $ref: "#/definitions/trailingEmptyLines" }
-                    },
-                    required: ["header"],
-                    additionalProperties: false,
-                    description: "Object-based extensible configuration format to use with the `header` rule."
-                },
-                options: {
-                    anyOf: [
-                        {
-                            type: "array",
-                            minItems: 1,
-                            maxItems: 1,
-                            items: { $ref: "#/definitions/newOptions" }
-                        },
-                        {
-                            type: "array",
-                            minItems: 1,
-                            maxItems: 2,
-                            items: [
-                                { type: "string" },
-                                { $ref: "#/definitions/settings" }
-                            ]
-                        },
-                        {
-                            type: "array",
-                            minItems: 2,
-                            maxItems: 3,
-                            items: [
-                                { $ref: "#/definitions/commentType" },
-                                { $ref: "#/definitions/headerLines" },
-                                { $ref: "#/definitions/settings" }
-                            ]
-                        },
-                        {
-                            type: "array",
-                            minItems: 3,
-                            maxItems: 4,
-                            items: [
-                                { $ref: "#/definitions/commentType" },
-                                { $ref: "#/definitions/headerLines" },
-                                { $ref: "#/definitions/numNewlines" },
-                                { $ref: "#/definitions/settings" }
-                            ]
-                        }
-                    ]
-                }
-            }
-        }
+        schema
     },
     /**
      * Rule creation function.
@@ -627,16 +444,36 @@ module.exports = {
                             eol,
                             options.trailingEmptyLines.minimum)
                     });
-                } else {
-                    const leadingComments = getLeadingComments(context, node);
+                    return;
+                }
 
-                    if (leadingComments[0].type.toLowerCase() !== options.header.commentType) {
+                const leadingComments = getLeadingComments(context, node);
+
+                if (leadingComments[0].type.toLowerCase() !== options.header.commentType) {
+                    context.report({
+                        loc: node.loc,
+                        message: "header should be a {{commentType}} comment",
+                        data: {
+                            commentType: options.header.commentType
+                        },
+                        fix: canFix
+                            ? genReplaceFixer(
+                                options.header.commentType,
+                                context,
+                                leadingComments,
+                                fixLines,
+                                eol,
+                                options.trailingEmptyLines.minimum)
+                            : null
+                    });
+                    return;
+                }
+
+                if (options.header.commentType === commentTypeOptions.line) {
+                    if (leadingComments.length < headerLines.length) {
                         context.report({
                             loc: node.loc,
-                            message: "header should be a {{commentType}} comment",
-                            data: {
-                                commentType: options.header.commentType
-                            },
+                            message: "incorrect header",
                             fix: canFix
                                 ? genReplaceFixer(
                                     options.header.commentType,
@@ -647,146 +484,129 @@ module.exports = {
                                     options.trailingEmptyLines.minimum)
                                 : null
                         });
-                    } else {
-                        if (options.header.commentType === commentTypeOptions.line) {
-                            if (leadingComments.length < headerLines.length) {
-                                context.report({
-                                    loc: node.loc,
-                                    message: "incorrect header",
-                                    fix: canFix
-                                        ? genReplaceFixer(
-                                            options.header.commentType,
-                                            context,
-                                            leadingComments,
-                                            fixLines,
-                                            eol,
-                                            options.trailingEmptyLines.minimum)
-                                        : null
-                                });
-                                return;
-                            }
-                            if (headerLines.length === 1) {
-                                const leadingCommentValues = leadingComments.map((c) => c.value);
-                                if (
-                                    !match(leadingCommentValues.join("\n"), headerLines[0])
-                                    && !match(leadingCommentValues.join("\r\n"), headerLines[0])
-                                ) {
-                                    context.report({
-                                        loc: node.loc,
-                                        message: "incorrect header",
-                                        fix: canFix
-                                            ? genReplaceFixer(
-                                                options.header.commentType,
-                                                context,
-                                                leadingComments,
-                                                fixLines,
-                                                eol,
-                                                options.trailingEmptyLines.minimum)
-                                            : null
-                                    });
-                                }
-                                return;
-                            }
-                            for (let i = 0; i < headerLines.length; i++) {
-                                if (!match(leadingComments[i].value, headerLines[i])) {
-                                    context.report({
-                                        loc: node.loc,
-                                        message: "incorrect header",
-                                        fix: canFix
-                                            ? genReplaceFixer(
-                                                options.header.commentType,
-                                                context,
-                                                leadingComments,
-                                                fixLines,
-                                                eol,
-                                                options.trailingEmptyLines.minimum)
-                                            : null
-                                    });
-                                    return;
-                                }
-                            }
-
-                            const start = leadingComments[headerLines.length - 1].range[1];
-                            const postLineHeader = context.sourceCode.text.substring(
-                                start,
-                                start + options.trailingEmptyLines.minimum * 2);
-                            if (!matchesLineEndings(postLineHeader, options.trailingEmptyLines.minimum)) {
-                                context.report({
-                                    loc: node.loc,
-                                    message: "no newline after header",
-                                    fix: canFix
-                                        ? genReplaceFixer(
-                                            options.header.commentType,
-                                            context,
-                                            leadingComments,
-                                            fixLines,
-                                            eol,
-                                            options.trailingEmptyLines.minimum)
-                                        : null
-                                });
-                            }
-
-                        } else {
-                            // if block comment pattern has more than 1 line, we
-                            // also split the comment
-                            let leadingLines = [leadingComments[0].value];
-                            if (headerLines.length > 1) {
-                                leadingLines = leadingComments[0].value.split(/\r?\n/);
-                            }
-
-                            let hasError = false;
-                            if (leadingLines.length > headerLines.length) {
-                                hasError = true;
-                            }
-                            for (let i = 0; !hasError && i < headerLines.length; i++) {
-                                const leadingLine = leadingLines[i];
-                                const headerLine = headerLines[i];
-                                if (!match(leadingLine, headerLine)) {
-                                    hasError = true;
-                                    break;
-                                }
-                            }
-
-                            if (hasError) {
-                                if (canFix && headerLines.length > 1) {
-                                    fixLines = [fixLines.join(eol)];
-                                }
-                                context.report({
-                                    loc: node.loc,
-                                    message: "incorrect header",
-                                    fix: canFix
-                                        ? genReplaceFixer(
-                                            options.header.commentType,
-                                            context,
-                                            leadingComments,
-                                            fixLines,
-                                            eol,
-                                            options.trailingEmptyLines.minimum)
-                                        : null
-                                });
-                            } else {
-                                const start = leadingComments[0].range[1];
-                                const postBlockHeader = context.sourceCode.text.substring(
-                                    start,
-                                    start + options.trailingEmptyLines.minimum * 2);
-                                if (!matchesLineEndings(postBlockHeader, options.trailingEmptyLines.minimum)) {
-                                    context.report({
-                                        loc: node.loc,
-                                        message: "no newline after header",
-                                        fix: canFix
-                                            ? genReplaceFixer(
-                                                options.header.commentType,
-                                                context,
-                                                leadingComments,
-                                                fixLines,
-                                                eol,
-                                                options.trailingEmptyLines.minimum)
-                                            : null
-                                    });
-                                }
-                            }
+                        return;
+                    }
+                    if (headerLines.length === 1) {
+                        const leadingCommentValues = leadingComments.map((c) => c.value);
+                        if (
+                            !match(leadingCommentValues.join("\n"), headerLines[0])
+                            && !match(leadingCommentValues.join("\r\n"), headerLines[0])
+                        ) {
+                            context.report({
+                                loc: node.loc,
+                                message: "incorrect header",
+                                fix: canFix
+                                    ? genReplaceFixer(
+                                        options.header.commentType,
+                                        context,
+                                        leadingComments,
+                                        fixLines,
+                                        eol,
+                                        options.trailingEmptyLines.minimum)
+                                    : null
+                            });
+                        }
+                        return;
+                    }
+                    for (let i = 0; i < headerLines.length; i++) {
+                        if (!match(leadingComments[i].value, headerLines[i])) {
+                            context.report({
+                                loc: node.loc,
+                                message: "incorrect header",
+                                fix: canFix
+                                    ? genReplaceFixer(
+                                        options.header.commentType,
+                                        context,
+                                        leadingComments,
+                                        fixLines,
+                                        eol,
+                                        options.trailingEmptyLines.minimum)
+                                    : null
+                            });
+                            return;
                         }
                     }
+
+                    const start = leadingComments[headerLines.length - 1].range[1];
+                    const postLineHeader = context.sourceCode.text.substring(
+                        start,
+                        start + options.trailingEmptyLines.minimum * 2);
+                    if (!matchesLineEndings(postLineHeader, options.trailingEmptyLines.minimum)) {
+                        context.report({
+                            loc: node.loc,
+                            message: "no newline after header",
+                            fix: canFix
+                                ? genReplaceFixer(
+                                    options.header.commentType,
+                                    context,
+                                    leadingComments,
+                                    fixLines,
+                                    eol,
+                                    options.trailingEmptyLines.minimum)
+                                : null
+                        });
+                    }
+                    return;
+                }
+
+                // if block comment pattern has more than 1 line, we
+                // also split the comment
+                let leadingLines = [leadingComments[0].value];
+                if (headerLines.length > 1) {
+                    leadingLines = leadingComments[0].value.split(/\r?\n/);
+                }
+
+                let hasError = false;
+                if (leadingLines.length > headerLines.length) {
+                    hasError = true;
+                }
+                for (let i = 0; !hasError && i < headerLines.length; i++) {
+                    const leadingLine = leadingLines[i];
+                    const headerLine = headerLines[i];
+                    if (!match(leadingLine, headerLine)) {
+                        hasError = true;
+                        break;
+                    }
+                }
+
+                if (hasError) {
+                    if (canFix && headerLines.length > 1) {
+                        fixLines = [fixLines.join(eol)];
+                    }
+                    context.report({
+                        loc: node.loc,
+                        message: "incorrect header",
+                        fix: canFix
+                            ? genReplaceFixer(
+                                options.header.commentType,
+                                context,
+                                leadingComments,
+                                fixLines,
+                                eol,
+                                options.trailingEmptyLines.minimum)
+                            : null
+                    });
+                    return;
+                }
+
+                const start = leadingComments[0].range[1];
+                const postBlockHeader = context.sourceCode.text.substring(
+                    start,
+                    start + options.trailingEmptyLines.minimum * 2);
+                if (!matchesLineEndings(postBlockHeader, options.trailingEmptyLines.minimum)) {
+                    context.report({
+                        loc: node.loc,
+                        message: "no newline after header",
+                        fix: canFix
+                            ? genReplaceFixer(
+                                options.header.commentType,
+                                context,
+                                leadingComments,
+                                fixLines,
+                                eol,
+                                options.trailingEmptyLines.minimum)
+                            : null
+                    });
                 }
             }
         };

--- a/lib/rules/header.schema.js
+++ b/lib/rules/header.schema.js
@@ -1,0 +1,211 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025-present Tony Ganchev and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+"use strict";
+
+/**
+ * @enum {string}
+ */
+const lineEndingOptions = Object.freeze({
+    os: "os",
+    unix: "unix",
+    windows: "windows",
+});
+
+/**
+ * @enum {string}
+ */
+const commentTypeOptions = Object.freeze({
+    block: "block",
+    line: "line"
+});
+
+const schema = Object.freeze({
+    $ref: "#/definitions/options",
+    definitions: {
+        commentType: {
+            type: "string",
+            enum: [commentTypeOptions.block, commentTypeOptions.line],
+            description: "Type of comment to expect as the header."
+        },
+        line: {
+            anyOf: [
+                {
+                    type: "string"
+                },
+                {
+                    type: "object",
+                    properties: {
+                        pattern: {
+                            type: "string"
+                        },
+                        template: {
+                            type: "string"
+                        }
+                    },
+                    required: ["pattern"],
+                    additionalProperties: false
+                }
+            ]
+        },
+        headerLines: {
+            anyOf: [
+                {
+                    $ref: "#/definitions/line"
+                },
+                {
+                    type: "array",
+                    items: {
+                        $ref: "#/definitions/line"
+                    }
+                }
+            ]
+        },
+        numNewlines: {
+            type: "integer",
+            minimum: 0
+        },
+        lineEndings: {
+            type: "string",
+            enum: [lineEndingOptions.unix, lineEndingOptions.windows, lineEndingOptions.os],
+            description: "Line endings to use when aut-fixing the violations. Defaults to 'os' which means 'same as " +
+            "system'."
+            // NOTE: default value not supported by the ajv schema validator.
+        },
+        settings: {
+            type: "object",
+            properties: {
+                lineEndings: { $ref: "#/definitions/lineEndings" },
+            },
+            additionalProperties: false
+        },
+        fileBasedHeader: {
+            type: "object",
+            properties: {
+                file: {
+                    type: "string",
+                    description: "Name of a file relative to the current directory (no back-tracking) that contains " +
+                        "the header template. It should contain a single block comment or a contiguous number of " +
+                        "line comments."
+                },
+                encoding: {
+                    type: "string",
+                    description: "Character encoding to use when parsing the file. Valid values are all encodings " +
+                        "that can be passed to `fs.readFileSync()`. If not specified, 'utf8' would be used."
+                    // NOTE: default value not supported by the ajv schema
+                    //       validator.
+                }
+            },
+            required: ["file"],
+            additionalProperties: false
+        },
+        inlineHeader: {
+            type: "object",
+            properties: {
+                commentType: { $ref: "#/definitions/commentType" },
+                lines: {
+                    type: "array",
+                    items: {
+                        $ref: "#/definitions/line"
+                    },
+                    description: "List of each line of the header - each being a string to match exactly or a " +
+                        "combination of a regex pattern to match and an optional template string as the fix."
+                }
+            },
+            required: ["commentType", "lines"],
+            additionalProperties: false
+        },
+        trailingEmptyLines: {
+            type: "object",
+            properties: {
+                minimum: {
+                    type: "number",
+                    description: "Number of empty lines required after the header. Defaults to 1.",
+                    // NOTE: default value not supported by the ajv schema
+                    //       validator.
+                }
+            },
+            additionalProperties: false,
+            description: "Configuration for how to validate and fix the set of empty lines after the header."
+        },
+        newOptions: {
+            type: "object",
+            properties: {
+                header: {
+                    anyOf: [
+                        { $ref: "#/definitions/fileBasedHeader" },
+                        { $ref: "#/definitions/inlineHeader" }
+                    ]
+                },
+                lineEndings: { $ref: "#/definitions/lineEndings" },
+                trailingEmptyLines: { $ref: "#/definitions/trailingEmptyLines" }
+            },
+            required: ["header"],
+            additionalProperties: false,
+            description: "Object-based extensible configuration format to use with the `header` rule."
+        },
+        options: {
+            anyOf: [
+                {
+                    type: "array",
+                    minItems: 1,
+                    maxItems: 1,
+                    items: { $ref: "#/definitions/newOptions" }
+                },
+                {
+                    type: "array",
+                    minItems: 1,
+                    maxItems: 2,
+                    items: [
+                        { type: "string" },
+                        { $ref: "#/definitions/settings" }
+                    ]
+                },
+                {
+                    type: "array",
+                    minItems: 2,
+                    maxItems: 3,
+                    items: [
+                        { $ref: "#/definitions/commentType" },
+                        { $ref: "#/definitions/headerLines" },
+                        { $ref: "#/definitions/settings" }
+                    ]
+                },
+                {
+                    type: "array",
+                    minItems: 3,
+                    maxItems: 4,
+                    items: [
+                        { $ref: "#/definitions/commentType" },
+                        { $ref: "#/definitions/headerLines" },
+                        { $ref: "#/definitions/numNewlines" },
+                        { $ref: "#/definitions/settings" }
+                    ]
+                }
+            ]
+        }
+    }
+});
+
+module.exports = { lineEndingOptions, commentTypeOptions, schema };


### PR DESCRIPTION
- split the schema to a separate file as it is bound to grow as  documentation is added.
- switched the `Program` hook to early returns to reduce nesting.