### PR TITLE
chore: add meta.defaultOptions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,7 +94,6 @@ const jsRules = {
         yoda: [2, "never"],
 
         "eslint-plugin/prefer-message-ids": 1,
-        "eslint-plugin/require-meta-default-options": 1,
 
         "n/callback-return": [2, ["cb", "callback", "next"]],
         "n/handle-callback-err": [2, "err"],

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -396,7 +396,16 @@ module.exports = {
     meta: {
         type: "layout",
         fixable: "whitespace",
-        schema
+        schema,
+        defaultOptions: [
+            /** @type {HeaderOptions} */
+            {
+                lineEndings: lineEndingOptions.os,
+                trailingEmptyLines: {
+                    minimum: 1
+                }
+            }
+        ]
     },
     /**
      * Rule creation function.

--- a/lib/rules/header.schema.js
+++ b/lib/rules/header.schema.js
@@ -91,7 +91,6 @@ const schema = Object.freeze({
             enum: [lineEndingOptions.unix, lineEndingOptions.windows, lineEndingOptions.os],
             description: "Line endings to use when aut-fixing the violations. Defaults to 'os' which means 'same as " +
             "system'."
-            // NOTE: default value not supported by the ajv schema validator.
         },
         settings: {
             type: "object",
@@ -114,7 +113,8 @@ const schema = Object.freeze({
                     description: "Character encoding to use when parsing the file. Valid values are all encodings " +
                         "that can be passed to `fs.readFileSync()`. If not specified, 'utf8' would be used."
                     // NOTE: default value not supported by the ajv schema
-                    //       validator.
+                    //       validator and there is no way to fix it through the
+                    //       plugin's `meta.defaultOptions`.
                 }
             },
             required: ["file"],
@@ -142,8 +142,6 @@ const schema = Object.freeze({
                 minimum: {
                     type: "number",
                     description: "Number of empty lines required after the header. Defaults to 1.",
-                    // NOTE: default value not supported by the ajv schema
-                    //       validator.
                 }
             },
             additionalProperties: false,


### PR DESCRIPTION
The change fixes one `eslint-plugin-eslint-plugin` violation and should aid documentation generation once it is in place.