### PR TITLE
refactor: switch to messageIds

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,8 +93,6 @@ const jsRules = {
         strict: [2, "global"],
         yoda: [2, "never"],
 
-        "eslint-plugin/prefer-message-ids": 1,
-
         "n/callback-return": [2, ["cb", "callback", "next"]],
         "n/handle-callback-err": [2, "err"],
         "n/no-mixed-requires": 2,

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -405,7 +405,13 @@ module.exports = {
                     minimum: 1
                 }
             }
-        ]
+        ],
+        messages: {
+            incorrectCommentType: "header should be a {{commentType}} comment",
+            incorrectHeader: "incorrect header",
+            missingHeader: "missing header",
+            noNewlineAfterHeader: "no newline after header"
+        }
     },
     /**
      * Rule creation function.
@@ -445,7 +451,7 @@ module.exports = {
                 if (!hasHeader(context.sourceCode.text)) {
                     context.report({
                         loc: node.loc,
-                        message: "missing header",
+                        messageId: "missingHeader",
                         fix: genPrependFixer(
                             options.header.commentType,
                             context,
@@ -461,7 +467,7 @@ module.exports = {
                 if (leadingComments[0].type.toLowerCase() !== options.header.commentType) {
                     context.report({
                         loc: node.loc,
-                        message: "header should be a {{commentType}} comment",
+                        messageId: "incorrectCommentType",
                         data: {
                             commentType: options.header.commentType
                         },
@@ -482,7 +488,7 @@ module.exports = {
                     if (leadingComments.length < headerLines.length) {
                         context.report({
                             loc: node.loc,
-                            message: "incorrect header",
+                            messageId: "incorrectHeader",
                             fix: canFix
                                 ? genReplaceFixer(
                                     options.header.commentType,
@@ -503,7 +509,7 @@ module.exports = {
                         ) {
                             context.report({
                                 loc: node.loc,
-                                message: "incorrect header",
+                                messageId: "incorrectHeader",
                                 fix: canFix
                                     ? genReplaceFixer(
                                         options.header.commentType,
@@ -521,7 +527,7 @@ module.exports = {
                         if (!match(leadingComments[i].value, headerLines[i])) {
                             context.report({
                                 loc: node.loc,
-                                message: "incorrect header",
+                                messageId: "incorrectHeader",
                                 fix: canFix
                                     ? genReplaceFixer(
                                         options.header.commentType,
@@ -543,7 +549,7 @@ module.exports = {
                     if (!matchesLineEndings(postLineHeader, options.trailingEmptyLines.minimum)) {
                         context.report({
                             loc: node.loc,
-                            message: "no newline after header",
+                            messageId: "noNewlineAfterHeader",
                             fix: canFix
                                 ? genReplaceFixer(
                                     options.header.commentType,
@@ -584,7 +590,7 @@ module.exports = {
                     }
                     context.report({
                         loc: node.loc,
-                        message: "incorrect header",
+                        messageId: "incorrectHeader",
                         fix: canFix
                             ? genReplaceFixer(
                                 options.header.commentType,
@@ -605,7 +611,7 @@ module.exports = {
                 if (!matchesLineEndings(postBlockHeader, options.trailingEmptyLines.minimum)) {
                     context.report({
                         loc: node.loc,
-                        message: "no newline after header",
+                        messageId: "noNewlineAfterHeader",
                         fix: canFix
                             ? genReplaceFixer(
                                 options.header.commentType,


### PR DESCRIPTION
The change ensures that any changes to messages are consolidated in the plugin rule meta array.

Addresses `eslint-plugin/prefer-message-ids`