### PR TITLE
devops: fix eslint-plugin/require-meta-docs-recommended

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,7 @@ const jsRules = {
         "eslint-plugin/prefer-placeholders": 2,
         "eslint-plugin/prefer-replace-text": 2,
         "eslint-plugin/report-message-format": 2,
+        "eslint-plugin/require-meta-docs-recommended": 2,
 
         "n/callback-return": [2, ["cb", "callback", "next"]],
         "n/handle-callback-err": [2, "err"],

--- a/lib/rules/header.docs.js
+++ b/lib/rules/header.docs.js
@@ -1,0 +1,28 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2025-present Tony Ganchev and contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+"use strict";
+
+exports.recommended = true;

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -27,8 +27,9 @@
 const assert = require("assert");
 const fs = require("fs");
 const os = require("os");
-const { lineEndingOptions, commentTypeOptions, schema } = require("./header.schema");
 const commentParser = require("../comment-parser");
+const { recommended } = require("./header.docs");
+const { lineEndingOptions, commentTypeOptions, schema } = require("./header.schema");
 
 /**
  * Import type definitions.
@@ -395,6 +396,9 @@ function normalizeOptions(originalOptions) {
 module.exports = {
     meta: {
         type: "layout",
+        docs: {
+            recommended
+        },
         fixable: "whitespace",
         schema,
         defaultOptions: [


### PR DESCRIPTION
A new rule-helper file is added to keep the docs as they may grow.