### PR TITLE
devops: fix eslint-plugin/require-meta-docs-description

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -98,6 +98,7 @@ const jsRules = {
         "eslint-plugin/prefer-placeholders": 2,
         "eslint-plugin/prefer-replace-text": 2,
         "eslint-plugin/report-message-format": 2,
+        "eslint-plugin/require-meta-docs-description": 2,
         "eslint-plugin/require-meta-docs-recommended": 2,
 
         "n/callback-return": [2, ["cb", "callback", "next"]],

--- a/lib/rules/header.docs.js
+++ b/lib/rules/header.docs.js
@@ -25,4 +25,6 @@
 
 "use strict";
 
+exports.description =
+    "ESLint plugin / rule to ensure that files begin with a given comment - usually a copyright notice.";
 exports.recommended = true;

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -28,7 +28,7 @@ const assert = require("assert");
 const fs = require("fs");
 const os = require("os");
 const commentParser = require("../comment-parser");
-const { recommended } = require("./header.docs");
+const { description, recommended } = require("./header.docs");
 const { lineEndingOptions, commentTypeOptions, schema } = require("./header.schema");
 
 /**
@@ -397,6 +397,7 @@ module.exports = {
     meta: {
         type: "layout",
         docs: {
+            description,
             recommended
         },
         fixable: "whitespace",


### PR DESCRIPTION
Copied over the summary from the README