### PR TITLE
fix: address all autofix cases where too many new lines get created

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -52,6 +52,7 @@
  * } HeaderOptions
  */
 
+const assert = require("assert");
 const fs = require("fs");
 const os = require("os");
 const commentParser = require("../comment-parser");
@@ -128,34 +129,48 @@ function getLeadingComments(context, node) {
  * @param {'block' | 'line'} commentType the type of comment to generate.
  * @param {string[]} textArray list of lines of the comment content.
  * @param {'\n' | '\r\n'} eol end-of-line characters.
- * @param {number} numNewlines number of trailing lines after the comment.
  * @returns {string} resulting comment.
  */
-function genCommentBody(commentType, textArray, eol, numNewlines) {
-    const eols = eol.repeat(numNewlines);
+function genCommentBody(commentType, textArray, eol) {
     if (commentType === commentTypeOptions.block) {
-        return "/*" + textArray.join(eol) + "*/" + eols;
+        return "/*" + textArray.join(eol) + "*/";
     } else {
-        return "//" + textArray.join(eol + "//") + eols;
+        // We need one trailing EOL on line comments to ensure the fixed source
+        // is parsable.
+        return "//" + textArray.join(eol + "//");
     }
 }
 
 /**
- * ...
- * @param {RuleContext} context ESLint rule execution context.
+ * Determines the start and end position in the source code of the leading
+ * comment.
  * @param {string[]} comments list of comments.
- * @param {'\n' | '\r\n'} eol end-of-line characters
  * @returns {[number, number]} resulting range.
  */
-function genCommentsRange(context, comments, eol) {
+function genCommentsRange(comments) {
     const start = comments[0].range[0];
-    let end = comments.slice(-1)[0].range[1];
-    const sourceCode = context.sourceCode.text;
-    const headerTrailingChars = sourceCode.substring(end, end + eol.length);
-    if (headerTrailingChars === eol) {
-        end += eol.length;
-    }
+    const end = comments.slice(-1)[0].range[1];
     return [start, end];
+}
+
+/**
+ * Calculates the number of leading empty lines in the source code. The function
+ * counts both Windows and POSIX line endings.
+ * @param {string} src the source code to traverse.
+ * @returns {number} the number of leading empty lines.
+ */
+function leadingEmptyLines(src) {
+    let numLines = 0;
+    while (true) {
+        const m = src.match(/^(\r\n|\n)/);
+        if (!m) {
+            break;
+        }
+        assert.strictEqual(m.index, 0);
+        numLines++;
+        src = src.slice(m.index + m[0].length);
+    }
+    return numLines;
 }
 
 /**
@@ -169,27 +184,29 @@ function genCommentsRange(context, comments, eol) {
  */
 function genPrependFixer(commentType, context, headerLines, eol, numNewlines) {
     return function(fixer) {
-        const newHeader = genCommentBody(commentType, headerLines, eol, numNewlines);
+        let insertPos = 0;
+        let newHeader = genCommentBody(commentType, headerLines, eol, numNewlines);
         if (context.sourceCode.text.substring(0, 2) === "#!") {
             const firstNewLinePos = context.sourceCode.text.indexOf("\n");
-            const insertPos = firstNewLinePos === -1 ? context.sourceCode.text.length : firstNewLinePos + 1;
-            return fixer.insertTextBeforeRange(
-                [insertPos, insertPos /* don't care */],
-                (firstNewLinePos === -1 ? eol : "") + newHeader
-            );
-        } else {
-            return fixer.insertTextBeforeRange(
-                [0, 0 /* don't care */],
-                newHeader
-            );
+            insertPos = firstNewLinePos === -1 ? context.sourceCode.text.length : firstNewLinePos + 1;
+            if (firstNewLinePos === -1) {
+                newHeader = eol + newHeader;
+            }
         }
+        const numEmptyLines = leadingEmptyLines(context.sourceCode.text.substring(insertPos));
+        const additionalEmptyLines = Math.max(0, numNewlines - numEmptyLines);
+        newHeader += eol.repeat(additionalEmptyLines);
+        return fixer.insertTextBeforeRange(
+            [insertPos, insertPos /* don't care */],
+            newHeader
+        );
     };
 }
 
 /**
  * Factory for fixer that replaces an incorrect header.
  * @param {'block' | 'line'} commentType type of comment to use.
- * @param {RuleContext} context ESLint rule execution context.
+ * @param {RuleContext} context ESLint execution context.
  * @param {Comment[]} leadingComments comment elements to replace.
  * @param {string[]} headerLines lines of the header comment.
  * @param {'\n' | '\r\n'} eol end-of-line characters
@@ -200,9 +217,32 @@ function genPrependFixer(commentType, context, headerLines, eol, numNewlines) {
  */
 function genReplaceFixer(commentType, context, leadingComments, headerLines, eol, numNewlines) {
     return function(fixer) {
+        const commentRange = genCommentsRange(leadingComments);
+        const emptyLines = leadingEmptyLines(context.sourceCode.text.substring(commentRange[1]));
+        const missingNewlines = Math.max(0, numNewlines - emptyLines);
+        const eols = eol.repeat(missingNewlines);
         return fixer.replaceTextRange(
-            genCommentsRange(context, leadingComments, eol),
-            genCommentBody(commentType, headerLines, eol, numNewlines)
+            commentRange,
+            genCommentBody(commentType, headerLines, eol, numNewlines) + eols
+        );
+    };
+}
+
+/**
+ * Factory for fixer that replaces an incorrect header.
+ * @param {Comment[]} leadingComments comment elements to replace.
+ * @param {'\n' | '\r\n'} eol end-of-line characters
+ * @param {number} missingEmptyLinesCount number of trailing lines after the
+ *                                        comment.
+ * @returns {
+ *  (fixer: RuleTextEditor) => RuleTextEdit | RuleTextEdit[] | null
+ * } the fixer.
+ */
+function genEmptyLinesFixer(leadingComments, eol, missingEmptyLinesCount) {
+    return function(fixer) {
+        return fixer.insertTextAfterRange(
+            genCommentsRange(leadingComments),
+            eol.repeat(missingEmptyLinesCount)
         );
     };
 }
@@ -258,25 +298,6 @@ function hasHeader(src) {
         }
     }
     return src.startsWith("/*") || src.startsWith("//");
-}
-
-/**
- * Ensures that the right amount of empty lines trail the header.
- * @param {string} src source to validate.
- * @param {number} num expected number of trailing empty lines.
- * @returns {boolean} `true` if the `num` number of empty lines are appended at
- *                    the end or `false` otherwise.
- */
-function matchesLineEndings(src, num) {
-    for (let j = 0; j < num; ++j) {
-        const m = src.match(/^(\r\n|\r|\n)/);
-        if (m) {
-            src = src.slice(m.index + m[0].length);
-        } else {
-            return false;
-        }
-    }
-    return true;
 }
 
 module.exports = {
@@ -374,7 +395,6 @@ module.exports = {
                     });
                     return;
                 }
-
                 if (commentType === commentTypeOptions.line) {
                     if (leadingComments.length < headerLines.length) {
                         context.report({
@@ -409,7 +429,8 @@ module.exports = {
                                     messageId: "incorrectHeader",
                                     fix: canFix
                                         ? genReplaceFixer(
-                                            commentType, context,
+                                            commentType,
+                                            context,
                                             leadingComments,
                                             fixLines,
                                             eol,
@@ -421,20 +442,18 @@ module.exports = {
                         }
                     }
 
-                    const postLineHeader =
-                        context.sourceCode.text.substring(leadingComments[headerLines.length - 1].range[1]);
-                    if (!matchesLineEndings(postLineHeader, numNewlines)) {
+                    const actualLeadingEmptyLines = leadingEmptyLines(
+                        context.sourceCode.text.substring(leadingComments[headerLines.length - 1].range[1]));
+                    const missingEmptyLines = numNewlines - actualLeadingEmptyLines;
+                    if (missingEmptyLines > 0) {
                         context.report({
                             loc: node.loc,
                             messageId: "noNewlineAfterHeader",
-                            fix: canFix
-                                ? genReplaceFixer(commentType, context, leadingComments, fixLines, eol, numNewlines)
-                                : null
+                            fix: canFix ? genEmptyLinesFixer(leadingComments, eol, missingEmptyLines) : null
                         });
                     }
                     return;
                 }
-
                 // if block comment pattern has more than 1 line, we also split
                 // the comment
                 let leadingLines = [leadingComments[0].value];
@@ -463,27 +482,20 @@ module.exports = {
                         loc: node.loc,
                         messageId: "incorrectHeader",
                         fix: canFix
-                            ? genReplaceFixer(
-                                commentType,
-                                context,
-                                leadingComments,
-                                fixLines,
-                                eol,
-                                numNewlines)
+                            ? genReplaceFixer(commentType, context, leadingComments, fixLines, eol, numNewlines)
                             : null
                     });
                     return;
                 }
 
-                const postBlockHeader = context.sourceCode.text.substring(leadingComments[0].range[1]);
-
-                if (!matchesLineEndings(postBlockHeader, numNewlines)) {
+                const actualLeadingEmptyLines = leadingEmptyLines(
+                    context.sourceCode.text.substring(leadingComments[0].range[1]));
+                const missingEmptyLines = numNewlines - actualLeadingEmptyLines;
+                if (missingEmptyLines > 0) {
                     context.report({
                         loc: node.loc,
                         messageId: "noNewlineAfterHeader",
-                        fix: canFix
-                            ? genReplaceFixer(commentType, context, leadingComments, fixLines, eol, numNewlines)
-                            : null
+                        fix: canFix ? genEmptyLinesFixer(leadingComments, eol, missingEmptyLines) : null
                     });
                 }
             }

--- a/lib/rules/test-utils.js
+++ b/lib/rules/test-utils.js
@@ -38,8 +38,9 @@ module.exports = {
      *                              modified.
      */
     generateInvalidTestCaseNames: function(invalidTests) {
+        let i = 1;
         for (const testCase of invalidTests) {
-            testCase.name = testCase.errors?.[0]?.message + " - [";
+            testCase.name = "" + i++ + ": " + testCase.errors?.[0]?.message + " - [";
             if (testCase.options?.length > 2 && typeof testCase.options[2] === "number") {
                 testCase.name += " " + testCase.options[2];
             }

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -254,7 +254,7 @@ describe("unix", () => {
                 errors: [
                     {message: "header should be a block comment"}
                 ],
-                output: "/*Copyright 2015, My Company*/\nconsole.log(1);"
+                output: "/*Copyright 2015, My Company*/\nconsole.log(1);",
             },
             {
                 code: "//Copyright 2014, My Company\nconsole.log(1);",
@@ -485,6 +485,30 @@ describe("unix", () => {
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
             {
+                code: "\n\n\n\n\nconsole.log(1);",
+                options: [
+                    "line",
+                    ["Copyright 2020", "My Company"],
+                    2
+                ],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "//Copyright 2020\n//My Company\n\n\n\n\nconsole.log(1);"
+            },
+            {
+                code: "\n\n\n\n\nconsole.log(1);",
+                options: [
+                    "block",
+                    ["", " * Copyright 2020", " * My Company", " "],
+                    2
+                ],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*\n * Copyright 2020\n * My Company\n */\n\n\n\n\nconsole.log(1);"
+            },
+            {
                 code: "//Copyright 2020 My Company\nconsole.log(1);",
                 options: ["line", "Copyright 2020 My Company", 3],
                 errors: [
@@ -501,13 +525,12 @@ describe("unix", () => {
                 output: "//Copyright 2020 My Company\n\n\nconsole.log(1);"
             },
             {
-                // TODO: this should not be right, documenting status quo
-                code: "\n\n\n\n\nconsole.log(1);",
+                code: "\n\n\n\nconsole.log(1);",
                 options: ["line", ["Copyright 2020", "My Company"], 2],
                 errors: [
                     {message: "missing header"}
                 ],
-                output: "//Copyright 2020\n//My Company\n\n\n\n\n\n\nconsole.log(1);"
+                output: "//Copyright 2020\n//My Company\n\n\n\nconsole.log(1);"
             },
             {
                 code: "#!/usr/bin/env node\nconsole.log(1);",
@@ -523,7 +546,7 @@ describe("unix", () => {
                 errors: [
                     {message: "missing header"},
                 ],
-                output: "#!/usr/bin/env node\n// Copyright\n\n\nconsole.log(1);",
+                output: "#!/usr/bin/env node\n// Copyright\n\nconsole.log(1);",
             },
             {
                 code: "#!/usr/bin/env node\n\n// My Company\nconsole.log(1);",
@@ -531,10 +554,10 @@ describe("unix", () => {
                 errors: [
                     {message: "missing header"},
                 ],
-                output: "#!/usr/bin/env node\n// Copyright\n\n// My Company\nconsole.log(1);",
+                output: "#!/usr/bin/env node\n// Copyright\n// My Company\nconsole.log(1);",
             },
             {
-                code: "#!/usr/bin/env node\n\n/* Copyright */\nconsole.log(1);",
+                code: "#!/usr/bin/env node\n\n\n/* Copyright */\nconsole.log(1);",
                 options: ["block", " Copyright "],
                 errors: [
                     {message: "missing header"},
@@ -1009,6 +1032,30 @@ describe("windows", () => {
                 ].join("\r\n")
             },
             {
+                code: "\r\n\r\n\r\n\r\n\r\nconsole.log(1);",
+                options: [
+                    "line",
+                    ["Copyright 2020", "My Company"],
+                    7
+                ],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "//Copyright 2020\r\n//My Company\r\n\r\n\r\n\r\n\r\n\r\n\r\nconsole.log(1);"
+            },
+            {
+                code: "\r\n\r\n\r\n\r\n\r\nconsole.log(1);",
+                options: [
+                    "block",
+                    ["", " * Copyright 2020", " * My Company", " "],
+                    2
+                ],
+                errors: [
+                    {message: "missing header"}
+                ],
+                output: "/*\r\n * Copyright 2020\r\n * My Company\r\n */\r\n\r\n\r\n\r\n\r\nconsole.log(1);"
+            },
+            {
                 code: "//Copyright 2020 My Company\r\nconsole.log(1);",
                 options: ["line", "Copyright 2020 My Company", 3],
                 errors: [
@@ -1030,7 +1077,7 @@ describe("windows", () => {
                 errors: [
                     {message: "missing header"}
                 ],
-                output: "//Copyright 2020\r\n//My Company\r\n\r\n\r\n\r\n\r\n\r\n\r\nconsole.log(1);"
+                output: "//Copyright 2020\r\n//My Company\r\n\r\n\r\n\r\n\r\nconsole.log(1);"
             },
             {
                 code: "#!/usr/bin/env node\r\nconsole.log(1);",
@@ -1046,7 +1093,7 @@ describe("windows", () => {
                 errors: [
                     {message: "missing header"},
                 ],
-                output: "#!/usr/bin/env node\r\n// Copyright\r\n\r\n\r\nconsole.log(1);",
+                output: "#!/usr/bin/env node\r\n// Copyright\r\n\r\nconsole.log(1);",
             },
             {
                 code: "#!/usr/bin/env node",

--- a/tests/lib/rules/test-utils.js
+++ b/tests/lib/rules/test-utils.js
@@ -45,7 +45,7 @@ describe("generateInvalidTestCaseNames", () => {
                     { message: "incorrect header" }
                 ],
             },
-            "incorrect header - [ ] - someCode();"
+            "1: incorrect header - [ ] - someCode();"
         ],
         [
             {
@@ -54,7 +54,7 @@ describe("generateInvalidTestCaseNames", () => {
                     { message: "incorrect header" }
                 ],
             },
-            "incorrect header - [ ] - someCode();\\nsomeOtherCode();"
+            "1: incorrect header - [ ] - someCode();\\nsomeOtherCode();"
         ],
         [
             {
@@ -63,7 +63,7 @@ describe("generateInvalidTestCaseNames", () => {
                     { message: "incorrect header" }
                 ],
             },
-            "incorrect header - [ ] - someCode();\\r\\nsomeOtherCode();"
+            "1: incorrect header - [ ] - someCode();\\r\\nsomeOtherCode();"
         ],
         [
             {
@@ -77,7 +77,7 @@ describe("generateInvalidTestCaseNames", () => {
                     { message: "incorrect header" }
                 ],
             },
-            "incorrect header - [ ] - someCode();\\n"
+            "1: incorrect header - [ ] - someCode();\\n"
                 + "someOtherCode();\\r\\n"
                 + "evenMore(code);\\n"
                 + "itIsNotFunny()\\n"
@@ -92,7 +92,7 @@ describe("generateInvalidTestCaseNames", () => {
                 ],
                 options: ["foo"]
             },
-            "incorrect header - [ ] - someCode();"
+            "1: incorrect header - [ ] - someCode();"
         ],
         [
             {
@@ -102,7 +102,7 @@ describe("generateInvalidTestCaseNames", () => {
                 ],
                 options: ["header.js", { lineEndings: "windows" }]
             },
-            "incorrect header - [ windows ] - someCode();"
+            "1: incorrect header - [ windows ] - someCode();"
         ],
         [
             {
@@ -112,7 +112,7 @@ describe("generateInvalidTestCaseNames", () => {
                 ],
                 options: ["line", ["Copyright 2025", "My Company"], { lineEndings: "unix" }]
             },
-            "incorrect header - [ unix line ] - someCode();"
+            "1: incorrect header - [ unix line ] - someCode();"
         ],
         [
             {
@@ -122,7 +122,7 @@ describe("generateInvalidTestCaseNames", () => {
                 ],
                 options: ["line", "Copyright 2025 My Company", 10]
             },
-            "missing header - [ 10 line ] - someCode();"
+            "1: missing header - [ 10 line ] - someCode();"
         ],
         [
             {
@@ -132,7 +132,7 @@ describe("generateInvalidTestCaseNames", () => {
                 ],
                 options: ["line", "Copyright 2025 My Company", 10, { lineEndings: "windows" }]
             },
-            "missing header - [ 10 windows line ] - someCode();"
+            "1: missing header - [ 10 windows line ] - someCode();"
         ],
     ];
     for (const [testCaseDef, expectedName] of testCases) {
@@ -141,4 +141,23 @@ describe("generateInvalidTestCaseNames", () => {
             assert.equal(modifiedTestCase.name, expectedName);
         });
     }
+    it("test case names are properly incremented", () => {
+        const invalidTestCases = [
+            {
+                code: "someCode();",
+                errors: [
+                    { message: "incorrect header" }
+                ],
+            },
+            {
+                code: "someOtherCode();",
+                errors: [
+                    { message: "incorrect header" }
+                ],
+            },
+        ];
+        const modifiedTestCases = generateInvalidTestCaseNames(invalidTestCases);
+        assert.equal(modifiedTestCases[0].name, "1: incorrect header - [ ] - someCode();");
+        assert.equal(modifiedTestCases[1].name, "2: incorrect header - [ ] - someOtherCode();");
+    });
 });


### PR DESCRIPTION
Fixes #76 

The cause of the problem is that all auto-fixes always append as many EOL characters after the header as the configured minimum number of required trailing empty lines. Thus, whenever there are already existing empty lines which are either not enough, or enough, but after an invalid header, the plugin will add more new lines.

The fix is to always count the number of empty lines that are already there and only append the minimum amount to have the source pass subsequent linting.

The refactored code allows us to add new capabilities in the future such as number of tolerated (but not required) lines etc.