### PR TITLE
imrpov: put more precise location when reporting missing empty lines

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -33,8 +33,6 @@ const { commentTypeOptions, lineEndingOptions, schema } = require("./header.sche
 
 /**
  * Import type definitions.
- * @typedef {import('estree').Comment} Comment
- * @typedef {import('estree').Program} Program
  * @typedef {import('eslint').Rule.Fix} Fix
  * @typedef {import('eslint').Rule.NodeListener} NodeListener
  * @typedef {import('eslint').Rule.ReportFixer} ReportFixer
@@ -42,6 +40,9 @@ const { commentTypeOptions, lineEndingOptions, schema } = require("./header.sche
  * @typedef {import('eslint').Rule.RuleTextEdit} RuleTextEdit
  * @typedef {import('eslint').Rule.RuleTextEditor} RuleTextEditor
  * @typedef {import('eslint').Rule.RuleContext} RuleContext
+ * @typedef {import('estree').Comment} Comment
+ * @typedef {import('estree').Program} Program
+ * @typedef {import("estree").SourceLocation} SourceLocation
  */
 
 /**
@@ -293,6 +294,30 @@ function hasHeader(src) {
     return srcWithoutShebang.startsWith("/*") || srcWithoutShebang.startsWith("//");
 }
 
+/**
+ * Calculates the source location of the violation that not enough empty lines
+ * follow the header.
+ * The behavior chosen is that the violation is shown over the empty (but
+ * insufficient) lines that trail the comment. A special case is when there are
+ * no empty lines after the header in which case we highlight the next character
+ * in the source regardless of which one it is).
+ * @param {Comment[]} leadingComments the comment lines that constitute the
+ *                                    header.
+ * @param {number} actualEmptyLines the number of empty lines that follow the
+ *                                  header.
+ * @returns {SourceLocation} the location (line and column) of the violation.
+ */
+function missingEmptyLinesViolationLoc(leadingComments, actualEmptyLines) {
+    const lastCommentLineLocEnd = leadingComments[leadingComments.length - 1].loc.end;
+    return {
+        start: lastCommentLineLocEnd,
+        end: {
+            column: actualEmptyLines === 0 ? lastCommentLineLocEnd.column + 1 : 0,
+            line: lastCommentLineLocEnd.line + actualEmptyLines
+        }
+    };
+}
+
 module.exports = {
     meta: {
         type: "layout",
@@ -440,13 +465,13 @@ module.exports = {
                     const missingEmptyLines = numNewlines - actualLeadingEmptyLines;
                     if (missingEmptyLines > 0) {
                         context.report({
-                            loc: node.loc,
+                            loc: missingEmptyLinesViolationLoc(leadingComments, actualLeadingEmptyLines),
                             messageId: "noNewlineAfterHeader",
                             data: {
                                 expected: numNewlines,
                                 actual: actualLeadingEmptyLines
                             },
-                            fix: canFix ? genEmptyLinesFixer(leadingComments, eol, missingEmptyLines) : null
+                            fix: genEmptyLinesFixer(leadingComments, eol, missingEmptyLines)
                         });
                     }
                     return;
@@ -490,13 +515,13 @@ module.exports = {
                 const missingEmptyLines = numNewlines - actualLeadingEmptyLines;
                 if (missingEmptyLines > 0) {
                     context.report({
-                        loc: node.loc,
+                        loc: missingEmptyLinesViolationLoc(leadingComments, actualLeadingEmptyLines),
                         messageId: "noNewlineAfterHeader",
                         data: {
                             expected: numNewlines,
                             actual: actualLeadingEmptyLines
                         },
-                        fix: canFix ? genEmptyLinesFixer(leadingComments, eol, missingEmptyLines) : null
+                        fix: genEmptyLinesFixer(leadingComments, eol, missingEmptyLines)
                     });
                 }
             }

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -401,7 +401,13 @@ describe("unix", () => {
                 code: "/*Copyright 2020, My Company*/console.log(1);",
                 options: ["block", "Copyright 2020, My Company", 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);"
             },
@@ -409,7 +415,13 @@ describe("unix", () => {
                 code: "/*Copyright 2020, My Company*/console.log(1);",
                 options: ["block", "Copyright 2020, My Company", 1],
                 errors: [
-                    { message: "not enough newlines after header: expected: 1, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 1, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\nconsole.log(1);"
             },
@@ -417,7 +429,13 @@ describe("unix", () => {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);",
                 options: ["line", ["Copyright 2020", "My Company"], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);"
             },
@@ -425,31 +443,56 @@ describe("unix", () => {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);",
                 options: ["line", [{ pattern: "Copyright 2020" }, "My Company"], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
+                output: "//Copyright 2020\n//My Company\n\nconsole.log(1);",
             },
             {
                 code: "/*Copyright 2020, My Company*/\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: ["block", "Copyright 2020, My Company", 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
             {
-                // TODO: this should be fixable since the pattern is correct and
-                //       only the new lines differ.
                 code: "/*Copyright 2020, My Company*/\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: ["block", [{ pattern: "Copyright 2020, My Company" }], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+
+                    }
                 ],
+                output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
             },
             {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "unix" }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
@@ -464,7 +507,13 @@ describe("unix", () => {
                 ].join("\r\n"),
                 options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "windows" }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: [
                     "//Copyright 2020",
@@ -480,7 +529,13 @@ describe("unix", () => {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: ["line", ["Copyright 2020", "My Company"], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
@@ -512,7 +567,13 @@ describe("unix", () => {
                 code: "//Copyright 2020 My Company\nconsole.log(1);",
                 options: ["line", "Copyright 2020 My Company", 3],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\n\n\nconsole.log(1);"
             },
@@ -520,7 +581,13 @@ describe("unix", () => {
                 code: "//Copyright 2020 My Company\nconsole.log(1);",
                 options: ["line", ["Copyright 2020 My Company"], 3],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\n\n\nconsole.log(1);"
             },
@@ -926,7 +993,13 @@ describe("windows", () => {
                 code: "/*Copyright 2020, My Company*/console.log(1);",
                 options: ["block", "Copyright 2020, My Company", 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\r\n\r\nconsole.log(1);"
             },
@@ -934,7 +1007,13 @@ describe("windows", () => {
                 code: "/*Copyright 2020, My Company*/console.log(1);",
                 options: ["block", "Copyright 2020, My Company", 1],
                 errors: [
-                    { message: "not enough newlines after header: expected: 1, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 1, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\r\nconsole.log(1);"
             },
@@ -942,7 +1021,13 @@ describe("windows", () => {
                 code: "//Copyright 2020\r\n//My Company\r\nconsole.log(1);",
                 options: ["line", ["Copyright 2020", "My Company"], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\r\n//My Company\r\n\r\nconsole.log(1);"
             },
@@ -950,14 +1035,27 @@ describe("windows", () => {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);",
                 options: ["line", [{ pattern: "Copyright 2020" }, "My Company"], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
+                output: "//Copyright 2020\n//My Company\r\n\nconsole.log(1);"
             },
             {
                 code: "/*Copyright 2020, My Company*/\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
                 options: ["block", "Copyright 2020, My Company", 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: [
                     "/*Copyright 2020, My Company*/",
@@ -972,7 +1070,13 @@ describe("windows", () => {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "unix" }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
@@ -987,7 +1091,13 @@ describe("windows", () => {
                 ].join("\r\n"),
                 options: ["line", ["Copyright 2020", "My Company"], 2, { lineEndings: "windows" }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: [
                     "//Copyright 2020",
@@ -1000,13 +1110,25 @@ describe("windows", () => {
                 ].join("\r\n")
             },
             {
-                // TODO: this should be fixable since the pattern is correct and
-                //       only the new lines differ.
                 code: "/*Copyright 2020, My Company*/\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
                 options: ["block", [{ pattern: "Copyright 2020, My Company" }], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
+                output: [
+                    "/*Copyright 2020, My Company*/",
+                    "",
+                    "console.log(1);",
+                    "//Comment",
+                    "console.log(2);",
+                    "//Comment"
+                ].join("\r\n")
             },
             {
                 code: [
@@ -1019,7 +1141,13 @@ describe("windows", () => {
                 ].join("\r\n"),
                 options: ["line", ["Copyright 2020", "My Company"], 2],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: [
                     "//Copyright 2020",
@@ -1059,7 +1187,13 @@ describe("windows", () => {
                 code: "//Copyright 2020 My Company\r\nconsole.log(1);",
                 options: ["line", "Copyright 2020 My Company", 3],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\r\n\r\n\r\nconsole.log(1);"
             },
@@ -1067,7 +1201,13 @@ describe("windows", () => {
                 code: "//Copyright 2020 My Company\r\nconsole.log(1);",
                 options: ["line", ["Copyright 2020 My Company"], 3],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\r\n\r\n\r\nconsole.log(1);"
             },


### PR DESCRIPTION
Now the location starts just after the end of the header and covers all empty lines.

Added validation for code location in tests.

fixes #84 and #92