### PR TITLE
imrpov: put more precise location when reporting missing empty lines …

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -33,8 +33,6 @@ const { lineEndingOptions, commentTypeOptions, schema } = require("./header.sche
 
 /**
  * Import type definitions.
- * @typedef {import('estree').Comment} Comment
- * @typedef {import('estree').Program} Program
  * @typedef {import('eslint').Rule.Fix} Fix
  * @typedef {import('eslint').Rule.NodeListener} NodeListener
  * @typedef {import('eslint').Rule.ReportFixer} ReportFixer
@@ -42,6 +40,9 @@ const { lineEndingOptions, commentTypeOptions, schema } = require("./header.sche
  * @typedef {import('eslint').Rule.RuleTextEdit} RuleTextEdit
  * @typedef {import('eslint').Rule.RuleTextEditor} RuleTextEditor
  * @typedef {import('eslint').Rule.RuleContext} RuleContext
+ * @typedef {import('estree').Comment} Comment
+ * @typedef {import('estree').Program} Program
+ * @typedef {import("estree").SourceLocation} SourceLocation
  */
 
 /**
@@ -413,6 +414,30 @@ function normalizeOptions(originalOptions) {
     return options;
 }
 
+/**
+ * Calculates the source location of the violation that not enough empty lines
+ * follow the header.
+ * The behavior chosen is that the violation is shown over the empty (but
+ * insufficient) lines that trail the comment. A special case is when there are
+ * no empty lines after the header in which case we highlight the next character
+ * in the source regardless of which one it is).
+ * @param {Comment[]} leadingComments the comment lines that constitute the
+ *                                    header.
+ * @param {number} actualEmptyLines the number of empty lines that follow the
+ *                                  header.
+ * @returns {SourceLocation} the location (line and column) of the violation.
+ */
+function missingEmptyLinesViolationLoc(leadingComments, actualEmptyLines) {
+    const lastCommentLineLocEnd = leadingComments[leadingComments.length - 1].loc.end;
+    return {
+        start: lastCommentLineLocEnd,
+        end: {
+            column: actualEmptyLines === 0 ? lastCommentLineLocEnd.column + 1 : 0,
+            line: lastCommentLineLocEnd.line + actualEmptyLines
+        }
+    };
+}
+
 module.exports = {
     meta: {
         type: "layout",
@@ -574,13 +599,13 @@ module.exports = {
                     const missingEmptyLines = options.trailingEmptyLines.minimum - actualLeadingEmptyLines;
                     if (missingEmptyLines > 0) {
                         context.report({
-                            loc: node.loc,
+                            loc: missingEmptyLinesViolationLoc(leadingComments, actualLeadingEmptyLines),
                             messageId: "noNewlineAfterHeader",
                             data: {
                                 expected: options.trailingEmptyLines.minimum,
                                 actual: actualLeadingEmptyLines
                             },
-                            fix: canFix ? genEmptyLinesFixer(leadingComments, eol, missingEmptyLines) : null
+                            fix: genEmptyLinesFixer(leadingComments, eol, missingEmptyLines)
                         });
                     }
                     return;
@@ -630,13 +655,13 @@ module.exports = {
                 const missingEmptyLines = options.trailingEmptyLines.minimum - actualLeadingEmptyLines;
                 if (missingEmptyLines > 0) {
                     context.report({
-                        loc: node.loc,
+                        loc: missingEmptyLinesViolationLoc(leadingComments, actualLeadingEmptyLines),
                         messageId: "noNewlineAfterHeader",
                         data: {
                             expected: options.trailingEmptyLines.minimum,
                             actual: actualLeadingEmptyLines
                         },
-                        fix: canFix ? genEmptyLinesFixer(leadingComments, eol, missingEmptyLines) : null
+                        fix: genEmptyLinesFixer(leadingComments, eol, missingEmptyLines)
                     });
                 }
             }

--- a/tests/lib/rules/header.js
+++ b/tests/lib/rules/header.js
@@ -751,7 +751,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);"
             },
@@ -767,7 +773,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 1, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 1, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\nconsole.log(1);"
             },
@@ -783,7 +795,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);"
             },
@@ -799,8 +817,15 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
+                output: "//Copyright 2020\n//My Company\n\nconsole.log(1);",
             },
             {
                 code: "/*Copyright 2020, My Company*/\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
@@ -814,20 +839,18 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
             {
-                // TODO: this should be fixable since the pattern is correct and
-                //       only the new lines differ.
-                code: [
-                    "/*Copyright 2020, My Company*/",
-                    "console.log(1);",
-                    "//Comment",
-                    "console.log(2);",
-                    "//Comment"
-                ].join("\n"),
+                code: "/*Copyright 2020, My Company*/\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
                 options: [{
                     header: {
                         commentType: "block",
@@ -838,8 +861,16 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+
+                    }
                 ],
+                output: "/*Copyright 2020, My Company*/\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
             },
             {
                 code: "//Copyright 2020\n//My Company\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment",
@@ -854,7 +885,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
@@ -878,7 +915,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: [
                     "//Copyright 2020",
@@ -902,7 +945,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
@@ -950,7 +999,13 @@ describe("unix", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\n\n\nconsole.log(1);"
             },
@@ -1673,7 +1728,13 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\r\n\r\nconsole.log(1);"
             },
@@ -1689,7 +1750,13 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 1, actual: 0" }
+                    {
+                        message: "not enough newlines after header: expected: 1, actual: 0",
+                        column: 31,
+                        endColumn: 32,
+                        endLine: 1,
+                        line: 1,
+                    }
                 ],
                 output: "/*Copyright 2020, My Company*/\r\nconsole.log(1);"
             },
@@ -1705,7 +1772,13 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\r\n//My Company\r\n\r\nconsole.log(1);"
             },
@@ -1721,8 +1794,15 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
+                output: "//Copyright 2020\n//My Company\r\n\nconsole.log(1);"
             },
             {
                 code: "/*Copyright 2020, My Company*/\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
@@ -1736,7 +1816,13 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 31,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: [
                     "/*Copyright 2020, My Company*/",
@@ -1760,13 +1846,17 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: "//Copyright 2020\n//My Company\n\nconsole.log(1);\n//Comment\nconsole.log(2);\n//Comment"
             },
             {
-                // TODO: this should be fixable since the pattern is correct and
-                //       only the new lines differ.
                 code: "/*Copyright 2020, My Company*/\r\nconsole.log(1);\r\n//Comment\r\nconsole.log(2);\r\n//Comment",
                 options: [{
                     header: {
@@ -1780,6 +1870,14 @@ describe("windows", () => {
                 errors: [
                     { message: "not enough newlines after header: expected: 2, actual: 1" }
                 ],
+                output: [
+                    "/*Copyright 2020, My Company*/",
+                    "",
+                    "console.log(1);",
+                    "//Comment",
+                    "console.log(2);",
+                    "//Comment"
+                ].join("\r\n")
             },
             {
                 code: [
@@ -1801,7 +1899,13 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: [
                     "//Copyright 2020",
@@ -1832,7 +1936,13 @@ describe("windows", () => {
                     }
                 }],
                 errors: [
-                    { message: "not enough newlines after header: expected: 2, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 2, actual: 1",
+                        column: 13,
+                        endColumn: 1,
+                        endLine: 3,
+                        line: 2,
+                    }
                 ],
                 output: [
                     "//Copyright 2020",
@@ -1880,7 +1990,13 @@ describe("windows", () => {
                 code: "//Copyright 2020 My Company\r\nconsole.log(1);",
                 options: ["line", "Copyright 2020 My Company", 3],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\r\n\r\n\r\nconsole.log(1);"
             },
@@ -1888,7 +2004,13 @@ describe("windows", () => {
                 code: "//Copyright 2020 My Company\r\nconsole.log(1);",
                 options: ["line", ["Copyright 2020 My Company"], 3],
                 errors: [
-                    { message: "not enough newlines after header: expected: 3, actual: 1" }
+                    {
+                        message: "not enough newlines after header: expected: 3, actual: 1",
+                        column: 28,
+                        endColumn: 1,
+                        endLine: 2,
+                        line: 1,
+                    }
                 ],
                 output: "//Copyright 2020 My Company\r\n\r\n\r\nconsole.log(1);"
             },


### PR DESCRIPTION
…(#87)

Now the location starts just after the end of the header and covers all empty lines.

fixes #84 and #92