### PR TITLE
ci: validate that ecosystem-tests catch regressions

### DIFF
--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -1044,6 +1044,20 @@ const headerRule = {
          * @returns {void}
          */
         function onRootNode(language) {
+            // TEMP: verify that ecosystem tests actually catch bugs.
+            context.report({
+                loc: {
+                    start: {
+                        column: 0,
+                        line: 1
+                    },
+                    end: {
+                        column: 0,
+                        line: 1
+                    }
+                },
+                messageId: "missingHeader"
+            });
             const options = normalizeOptions(newStyleOptions, language);
             const eol = getEol(/** @type {LineEndingOption} */(options.lineEndings));
             const header = /** @type {InlineConfig} */ (options.header);

--- a/lib/rules/header.js
+++ b/lib/rules/header.js
@@ -1043,6 +1043,20 @@ const headerRule = {
          * @returns {void}
          */
         function onRootNode(language) {
+            // TEMP: verify that ecosystem tests actually catch bugs.
+            context.report({
+                loc: {
+                    start: {
+                        column: 0,
+                        line: 1
+                    },
+                    end: {
+                        column: 0,
+                        line: 1
+                    }
+                },
+                messageId: "missingHeader"
+            });
             const options = normalizeOptions(newStyleOptions, language);
             const eol = getEol(/** @type {LineEndingOption} */(options.lineEndings));
             const header = /** @type {InlineConfig} */ (options.header);


### PR DESCRIPTION
**THIS PR IS KEPT OPEN FOR TESTING PURPOSES AND WILL OCCASIONALLY BE REBASED TO TEST NEWLY ADDED ECOSYSTEM TESTS FOR CORRECTNESS**